### PR TITLE
ssh: Respect the user and password provided by the caller

### DIFF
--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -470,8 +470,8 @@ class MultihostRole(Generic[HostType]):
         """
         return SSHClient(
             self.host.ssh_host,
-            user=self.host.ssh_username,
-            password=self.host.ssh_password,
+            user=self.host.ssh_username if user is None else user,
+            password=self.host.ssh_password if password is None else password,
             port=self.host.ssh_port,
             shell=shell,
             logger=self.mh.logger,


### PR DESCRIPTION
This piece of code fails because the user and password provided by the caller are not used.
```
    with client.ssh('ci', 'Secret123') as ssh:
        result = ssh.run('whoami')
        assert result.rc == 0
        assert result.stdout == 'ci'
```
This commit fixed that using them whenever they are available.