### PR TITLE
markers: add require marker

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,5 +96,6 @@ What does the framework do?
    config
    topology
    classes
+   runtime-requirements
    pytest
    api

--- a/docs/runtime-requirements.rst
+++ b/docs/runtime-requirements.rst
@@ -1,0 +1,54 @@
+Additional runtime requirements
+###############################
+
+Sometimes, topology itself is not enough to detect if the test can or can not
+be run and you want to check for a runtime requirement like that your program
+was built with certain configure flags or features.
+
+This can be achieved with ``pytest.mark.require(condition[, reason])`` marker
+that takes a function as a parameter and the test is skipped if the function
+returns ``False`` (the requirement was not met).
+
+The function takes all fixtures that are available to the test as parameters.
+
+.. note::
+
+    The function can either return ``bool`` or ``tuple[bool, str]``. In this
+    case, the second value is the reason for skipping the test.
+
+.. code-block:: python
+
+    @pytest.mark.topology(KnownTopology.LDAP)
+    @pytest.mark.require(
+        lambda client: "files-provider" in client.features,
+        "SSSD was not built with files provider"
+    )
+    def test_example_explicit_reason(client: Client, ldap: LDAP):
+        pass
+
+    @pytest.mark.topology(KnownTopology.LDAP)
+    @pytest.mark.require(
+        lambda client: ("files-provider" in client.features, "SSSD was not built with files provider")
+    )
+    def test_example_reason_as_tuple(client: Client, ldap: LDAP):
+        pass
+
+.. note::
+
+    The requirement is evaluated when the test is executed but before setup
+    phase, so no setup method was called on any multihost role in order to make
+    the skip fast.
+
+    If you require to setup the role, you can always call the setup method
+    directly from the function passed to the ``require`` marker.
+
+.. warning::
+
+    ``pytest-mh`` provides the ``requirement`` marker as a generic way to skip
+    a test when a condition is not met. The condition can use multihost roles
+    or other pytest fixtures used by the marked test and it can also call
+    commands on remote hosts.
+
+    The example above shows a check if an SSSD project was built with
+    "files-provider" feature, however feature detection is not part of
+    ``pytest-mh`` since feature detection is project specific mechanism.

--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import inspect
+from functools import partial
 from types import SimpleNamespace
 from typing import Generator
 
@@ -84,6 +86,7 @@ class MultihostFixture(object):
         """
 
         self._paths: dict[str, list[MultihostRole] | MultihostRole] = {}
+        self._skipped: bool = False
 
         for domain in self.multihost.domains:
             if domain.id in topology:
@@ -134,11 +137,66 @@ class MultihostFixture(object):
 
         return list(set([*hosts, *roles]))
 
+    def _skip(self) -> bool:
+        if self.data.topology_mark is None:
+            raise ValueError("Multihost fixture is available but no topology mark was set")
+
+        self._skipped = False
+
+        fixtures = self.request.node.funcargs
+        self.data.topology_mark.apply(self, fixtures)
+
+        for mark in self.request.node.iter_markers("require"):
+            if len(mark.args) not in [1, 2]:
+                raise ValueError(
+                    f"{self.request.node.nodeid}::{self.request.node.originalname}: "
+                    "invalid arguments for @pytest.mark.require"
+                )
+
+            condition = mark.args[0]
+            reason = "Required condition was not met" if len(mark.args) != 2 else mark.args[1]
+
+            args: list[str] = []
+            if isinstance(condition, partial):
+                spec = inspect.getfullargspec(condition.func)
+
+                # Remove bound positional parameters
+                args = spec.args[len(condition.args) :]
+
+                # Remove bound keyword parameters
+                args = [x for x in args if x not in condition.keywords]
+            else:
+                spec = inspect.getfullargspec(condition)
+                args = spec.args
+
+            callspec = {k: v for k, v in fixtures.items() if k in args}
+            callresult = condition(**callspec)
+            if isinstance(callresult, tuple):
+                if len(callresult) != 2:
+                    raise ValueError(
+                        f"{self.request.node.nodeid}::{self.request.node.originalname}: "
+                        "invalid arguments for @pytest.mark.require"
+                    )
+
+                result = callresult[0]
+                reason = callresult[1]
+            else:
+                result = callresult
+
+            if not result:
+                self._skipped = True
+                pytest.skip(reason)
+
+        return self._skipped
+
     def _setup(self) -> None:
         """
         Setup multihost. A setup method is called on each host and role
         to initialize the test environment to expected state.
         """
+        if self._skipped:
+            return
+
         mh_log_phase(self.logger, self.request, "SETUP")
         try:
             setup_ok: list[MultihostHost | MultihostRole] = []
@@ -161,6 +219,9 @@ class MultihostFixture(object):
         that were made during a test run. It is automatically called when the
         test is finished.
         """
+        if self._skipped:
+            return
+
         mh_log_phase(self.logger, self.request, "TEARDOWN")
         try:
             errors = []
@@ -188,6 +249,9 @@ class MultihostFixture(object):
         :param host: Host object where the artifacts will be collected.
         :type host: MultihostHost
         """
+        if self._skipped:
+            return
+
         dir = self.request.config.getoption("mh_artifacts_dir")
         mode = self.request.config.getoption("mh_collect_artifacts")
         if mode == "never" or (mode == "on-failure" and self.data.outcome != "failed"):
@@ -200,6 +264,9 @@ class MultihostFixture(object):
         host.collect_artifacts(f"{dir}/{name}")
 
     def __enter__(self) -> MultihostFixture:
+        if self._skip():
+            return self
+
         self._setup()
         return self
 

--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -432,4 +432,10 @@ def pytest_configure(config: pytest.Config):
         + "*, fixture1=target1, ...): topology required to run the test",
     )
 
+    config.addinivalue_line(
+        "markers",
+        "require(condition, reason): evaluate condition, parameters may be topology fixture, "
+        "the test is skipped if condition is not met",
+    )
+
     config.pluginmanager.register(MultihostPlugin(config), "MultihostPlugin")


### PR DESCRIPTION
Add additional runtime requirement, skip test if requirement is not met.

```python
@pytest.mark.require(lambda client: "files-provider" in client.features)
```