### PR TITLE
multihost: artifacts collection fix

### DIFF
--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -135,7 +135,7 @@ class MultihostFixture(object):
         roles: list[MultihostRole] = [x for x in self._paths.values() if isinstance(x, MultihostRole)]
         hosts: list[MultihostHost] = [x.host for x in roles]
 
-        return list(set([*hosts, *roles]))
+        return [*hosts, *roles]
 
     def _skip(self) -> bool:
         if self.data.topology_mark is None:


### PR DESCRIPTION
Teardown of <sssd_test_framework.hosts.client.ClientHost object at 0x7f461e9f79d0> can happen which triggers restoring backup data before teardown of sssd_test_framework.roles.client.Client object occurs to collect artifacts.