### PR TITLE
requirements: avoid installing ssh2-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+--no-dependencies parallel-ssh
 colorama
-parallel-ssh
+gevent
 pytest
 PyYAML
+ssh-python


### PR DESCRIPTION
ssh2-python is a dependency of parallel-ssh but does not currently
work on python-3.12. We use ssh-python in parallel-ssh so we can
avoid installing this dependency until it is fixed.