### PR TITLE
mh: always log a hostname in a log message

### DIFF
--- a/pytest_mh/_private/misc.py
+++ b/pytest_mh/_private/misc.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+
+def merge_dict(d1, d2):
+    """
+    Merge two nested dictionaries together.
+
+    Nested dictionaries are not overwritten but combined.
+    """
+    dest = deepcopy(d1)
+    for key, value in d2.items():
+        if isinstance(value, dict):
+            dest[key] = merge_dict(dest.get(key, {}), value)
+            continue
+
+        dest[key] = value
+
+    return dest

--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Generic, Type, TypeVar
 
 from ..cli import CLIBuilder
 from ..ssh import SSHBashProcess, SSHClient, SSHLog, SSHPowerShellProcess, SSHProcess
-from .logging import MultihostLogger
+from .logging import MultihostHostLogger, MultihostLogger
 from .marks import TopologyMark
 from .utils import validate_configuration
 
@@ -277,14 +277,16 @@ class MultihostHost(Generic[DomainType]):
         self.domain: DomainType = domain
         """Multihost domain."""
 
-        self.logger: MultihostLogger = domain.logger
-        """Multihost logger."""
-
         self.role: str = confdict["role"]
         """Host role."""
 
         self.hostname: str = confdict["hostname"]
         """Host hostname."""
+
+        self.logger: MultihostLogger = self.domain.logger.subclass(
+            cls=MultihostHostLogger, suffix=f"host.{self.hostname}", hostname=self.hostname
+        )
+        """Multihost logger."""
 
         # Optional
         self.config: dict[str, Any] = confdict.get("config", {})
@@ -441,6 +443,9 @@ class MultihostRole(Generic[HostType]):
         self.role: str = role
         self.host: HostType = host
 
+        self.logger: MultihostLogger = self.host.logger
+        """Multihost logger."""
+
     def setup(self) -> None:
         """
         Setup all :class:`MultihostUtility` objects
@@ -474,7 +479,7 @@ class MultihostRole(Generic[HostType]):
             password=password,
             port=self.host.ssh_port,
             shell=shell,
-            logger=self.mh.logger,
+            logger=self.logger,
         )
 
 

--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -82,7 +82,7 @@ class MultihostPlugin(object):
         self.confdict = self.__load_conf(self.mh_config)
 
         logger = MultihostLogger.GetLogger()
-        logger.setup(self.mh_log_path)
+        logger.setup(log_path=self.mh_log_path, confdict=self.confdict)
 
         self.multihost = self.config_class(self.confdict, logger=logger, lazy_ssh=self.mh_lazy_ssh)
         self.topology = Topology.FromMultihostConfig(self.confdict)

--- a/pytest_mh/utils/firewall.py
+++ b/pytest_mh/utils/firewall.py
@@ -171,7 +171,7 @@ class LinuxFirewalld(GenericFirewall):
         :param rule: Firewalld rich rule.
         :type rule: str
         """
-        self.logger.info(f'Firewalld: adding rich rule "{rule}" on {self.host.hostname}')
+        self.logger.info(f'Firewalld: adding rich rule "{rule}"')
         self.host.ssh.exec(["firewall-cmd", "--add-rich-rule", rule], log_level=SSHLog.Error)
 
     def remove_rich_rule(self, rule: str) -> None:
@@ -181,7 +181,7 @@ class LinuxFirewalld(GenericFirewall):
         :param rule: Firewalld rich rule.
         :type rule: str
         """
-        self.logger.info(f'Firewalld: removing rich rule  "{rule}" on {self.host.hostname}')
+        self.logger.info(f'Firewalld: removing rich rule  "{rule}"')
         self.host.ssh.exec(["firewall-cmd", "--remove-rich-rule", rule], log_level=SSHLog.Error)
 
     def __add_action(
@@ -233,7 +233,7 @@ class WindowsFirewall(GenericFirewall):
         :meta private:
         """
         super().setup_when_used()
-        self.logger.info(f"Windows Firewall: creating backup at '{self._backup}' on {self.host.hostname}")
+        self.logger.info(f"Windows Firewall: creating backup at '{self._backup}'")
         self.host.ssh.run(
             f"Remove-Item {self._backup}; netsh advfirewall export {self._backup}", log_level=SSHLog.Error
         )
@@ -244,7 +244,7 @@ class WindowsFirewall(GenericFirewall):
 
         :meta private:
         """
-        self.logger.info(f"Windows Firewall: restoring from '{self._backup}' on {self.host.hostname}")
+        self.logger.info(f"Windows Firewall: restoring from '{self._backup}'")
         self.host.ssh.run(f"netsh advfirewall reset; netsh advfirewall import {self._backup}", log_level=SSHLog.Error)
         super().teardown_when_used()
 
@@ -297,6 +297,6 @@ class WindowsFirewall(GenericFirewall):
             remove = f"Remove-NetFirewallRule -DisplayName '{opposite}'; " if opposite in self._rules else ""
             add = f"New-NetFirewallRule -DisplayName '{name}' -Action {action} -Protocol {protocol} -LocalPort {port}"
 
-            self.logger.info(f'Windows Firewall: {action} "{port}/{protocol}" on {self.host.hostname}')
+            self.logger.info(f'Windows Firewall: {action} "{port}/{protocol}"')
             self.host.ssh.run(f"{remove}{add}", log_level=SSHLog.Error)
             self._rules.append(name)

--- a/pytest_mh/utils/fs.py
+++ b/pytest_mh/utils/fs.py
@@ -51,7 +51,7 @@ class LinuxFileSystem(MultihostUtility):
         :type group: str | None, optional
         """
         self.backup(path)
-        self.logger.info(f'Creating directory "{path}" on {self.host.hostname}')
+        self.logger.info(f'Creating directory "{path}"')
         self.host.ssh.run(
             f"""
                 set -ex
@@ -78,7 +78,7 @@ class LinuxFileSystem(MultihostUtility):
         :type group: str | None, optional
         """
         self.backup(path)
-        self.logger.info(f'Creating directory "{path}" (with parents) on {self.host.hostname}')
+        self.logger.info(f'Creating directory "{path}" (with parents)')
         result = self.host.ssh.run(
             f"""
                 set -ex
@@ -119,7 +119,7 @@ class LinuxFileSystem(MultihostUtility):
         :rtype: str
         """
 
-        self.logger.info(f"Creating temporary file on {self.host.hostname}")
+        self.logger.info("Creating temporary file")
         result = self.host.ssh.run(
             """
                 set -ex
@@ -139,9 +139,7 @@ class LinuxFileSystem(MultihostUtility):
             if dedent:
                 contents = textwrap.dedent(contents).strip()
 
-            self.logger.info(
-                f'Writing file "{tmpfile}" on {self.host.hostname}', extra={"data": {"Contents": contents}}
-            )
+            self.logger.info(f'Writing file "{tmpfile}"', extra={"data": {"Contents": contents}})
             self.host.ssh.run(f"cat > '{tmpfile}'", input=contents, log_level=SSHLog.Error)
 
         attrs = self.__gen_chattrs(tmpfile, mode=mode, user=user, group=group)
@@ -158,7 +156,7 @@ class LinuxFileSystem(MultihostUtility):
         :type path: str
         """
         self.backup(path)
-        self.logger.info(f'Removing file "{path}" on {self.host.hostname}')
+        self.logger.info(f'Removing file "{path}"')
 
         self.host.ssh.run(
             f"""
@@ -177,7 +175,7 @@ class LinuxFileSystem(MultihostUtility):
         :return: File contents.
         :rtype: str
         """
-        self.logger.info(f'Reading file "{path}" on {self.host.hostname}')
+        self.logger.info(f'Reading file "{path}"')
         result = self.host.ssh.exec(["cat", path], log_level=SSHLog.Error)
 
         return result.stdout
@@ -191,7 +189,7 @@ class LinuxFileSystem(MultihostUtility):
         :return: True or False
         :rtype: bool
         """
-        self.logger.info(f'Checking "{path}" exists on {self.host.hostname}')
+        self.logger.info(f'Checking if "{path}" exists')
         result = self.host.ssh.exec(["ls", path], log_level=SSHLog.Error, raise_on_error=False)
 
         if result.rc == 0:
@@ -229,7 +227,7 @@ class LinuxFileSystem(MultihostUtility):
             contents = textwrap.dedent(contents).strip()
 
         self.backup(path)
-        self.logger.info(f'Writing file "{path}" on {self.host.hostname}', extra={"data": {"Contents": contents}})
+        self.logger.info(f'Writing file "{path}"', extra={"data": {"Contents": contents}})
 
         self.host.ssh.run(
             f"""
@@ -263,7 +261,7 @@ class LinuxFileSystem(MultihostUtility):
             contents = textwrap.dedent(contents).strip()
 
         self.backup(path)
-        self.logger.info(f'Appending to file "{path}" on {self.host.hostname}', extra={"data": {"Contents": contents}})
+        self.logger.info(f'Appending to file "{path}"', extra={"data": {"Contents": contents}})
 
         self.host.ssh.run(
             f"""
@@ -297,7 +295,7 @@ class LinuxFileSystem(MultihostUtility):
         :type dedent: bool, optional
         """
         self.backup(path)
-        self.logger.info(f'Touching file "{path}" on {self.host.hostname}')
+        self.logger.info(f'Touching file "{path}"')
 
         self.host.ssh.run(
             f"""
@@ -323,7 +321,7 @@ class LinuxFileSystem(MultihostUtility):
         :type size: int, optional
         """
         self.backup(path)
-        self.logger.info(f'Truncating file "{path}" on {self.host.hostname}', extra={"data": {"Size": size}})
+        self.logger.info(f'Truncating file "{path}"', extra={"data": {"Size": size}})
 
         self.host.ssh.run(
             f"""
@@ -359,7 +357,7 @@ class LinuxFileSystem(MultihostUtility):
         :type dedent: bool, optional
         """
         self.backup(dstpath)
-        self.logger.info(f'Copying file "{srcpath}" to "{dstpath}" on {self.host.hostname}')
+        self.logger.info(f'Copying file "{srcpath}" to "{dstpath}"')
 
         self.host.ssh.run(
             f"""
@@ -451,7 +449,7 @@ class LinuxFileSystem(MultihostUtility):
         :param local_path: Local path.
         :type local_path: str
         """
-        self.logger.info(f'Downloading file "{remote_path}" from {self.host.hostname} to "{local_path}"')
+        self.logger.info(f'Downloading file "{self.host.hostname}:{remote_path}" to "{local_path}"')
         result = self.host.ssh.exec(["base64", remote_path], log_level=SSHLog.Error)
         with open(local_path, "wb") as f:
             f.write(base64.b64decode(result.stdout))
@@ -504,7 +502,7 @@ class LinuxFileSystem(MultihostUtility):
             # Backup is already present
             return True
 
-        self.logger.info(f'Creating a backup of "{path}" on {self.host.hostname}')
+        self.logger.info(f'Creating a backup of "{path}"')
         result = self.host.ssh.run(
             f"""
         set -ex
@@ -551,7 +549,7 @@ class LinuxFileSystem(MultihostUtility):
             # Backup is not present
             return False
 
-        self.logger.info(f'Restoring "{path}" from backup on {self.host.hostname}')
+        self.logger.info(f'Restoring "{path}" from backup')
         self.host.ssh.run(action, log_level=SSHLog.Error)
 
         self.__rollback.remove(action)
@@ -626,6 +624,6 @@ class LinuxFileSystem(MultihostUtility):
         :rtype: SSHProcessResult
         """
         self.backup(path)
-        self.logger.info(f'Changing mode bits for "{path}" on {self.host.hostname}')
+        self.logger.info(f'Changing mode bits for "{path}"')
 
         return self.host.ssh.exec(["chmod", *args, mode, path])

--- a/pytest_mh/utils/services.py
+++ b/pytest_mh/utils/services.py
@@ -19,9 +19,17 @@ class SystemdServices(MultihostUtility):
         # Restart all services that were touched
         self.reload_daemon()
         for service, state in self.initial_states.items():
-            self.host.ssh.run(f'systemctl stop "{service}" || systemctl status "{service}"', raise_on_error=False)
+            self.host.ssh.run(
+                f'systemctl stop "{service}" || systemctl status "{service}"',
+                raise_on_error=False,
+                log_level=SSHLog.Error,
+            )
             if state:
-                self.host.ssh.run(f'systemctl start "{service}" || systemctl status "{service}"', raise_on_error=False)
+                self.host.ssh.run(
+                    f'systemctl start "{service}" || systemctl status "{service}"',
+                    raise_on_error=False,
+                    log_level=SSHLog.Error,
+                )
 
     def async_start(self, service: str) -> SSHProcess:
         """
@@ -36,7 +44,10 @@ class SystemdServices(MultihostUtility):
         :rtype: SSHProcess
         """
         self.__set_initial_state(service)
-        return self.host.ssh.async_run(f'systemctl start "{service}" || systemctl status "{service}"')
+        self.logger.info(f'systemd: starting "{service}" asynchronously')
+        return self.host.ssh.async_run(
+            f'systemctl start "{service}" || systemctl status "{service}"', log_level=SSHLog.Error
+        )
 
     def start(self, service: str, raise_on_error: bool = True) -> SSHProcessResult:
         """
@@ -53,8 +64,11 @@ class SystemdServices(MultihostUtility):
         :rtype: SSHProcessResult
         """
         self.__set_initial_state(service)
+        self.logger.info(f'systemd: starting "{service}"')
         return self.host.ssh.run(
-            f'systemctl start "{service}" || systemctl status "{service}"', raise_on_error=raise_on_error
+            f'systemctl start "{service}" || systemctl status "{service}"',
+            raise_on_error=raise_on_error,
+            log_level=SSHLog.Error,
         )
 
     def async_stop(self, service: str) -> SSHProcess:
@@ -70,7 +84,10 @@ class SystemdServices(MultihostUtility):
         :rtype: SSHProcess
         """
         self.__set_initial_state(service)
-        return self.host.ssh.async_run(f'systemctl stop "{service}" || systemctl status "{service}"')
+        self.logger.info(f'systemd: stopping "{service}" asynchronously')
+        return self.host.ssh.async_run(
+            f'systemctl stop "{service}" || systemctl status "{service}"', log_level=SSHLog.Error
+        )
 
     def stop(self, service: str, raise_on_error: bool = True) -> SSHProcessResult:
         """
@@ -87,8 +104,11 @@ class SystemdServices(MultihostUtility):
         :rtype: SSHProcessResult
         """
         self.__set_initial_state(service)
+        self.logger.info(f'systemd: stopping "{service}"')
         return self.host.ssh.run(
-            f'systemctl stop "{service}" || systemctl status "{service}"', raise_on_error=raise_on_error
+            f'systemctl stop "{service}" || systemctl status "{service}"',
+            raise_on_error=raise_on_error,
+            log_level=SSHLog.Error,
         )
 
     def async_restart(self, service: str) -> SSHProcess:
@@ -104,7 +124,10 @@ class SystemdServices(MultihostUtility):
         :rtype: SSHProcess
         """
         self.__set_initial_state(service)
-        return self.host.ssh.async_run(f'systemctl restart "{service}" || systemctl status "{service}"')
+        self.logger.info(f'systemd: restarting "{service}" asynchronously')
+        return self.host.ssh.async_run(
+            f'systemctl restart "{service}" || systemctl status "{service}"', log_level=SSHLog.Error
+        )
 
     def restart(self, service: str, raise_on_error: bool = True) -> SSHProcessResult:
         """
@@ -121,8 +144,11 @@ class SystemdServices(MultihostUtility):
         :rtype: SSHProcessResult
         """
         self.__set_initial_state(service)
+        self.logger.info(f'systemd: restarting "{service}"')
         return self.host.ssh.run(
-            f'systemctl restart "{service}" || systemctl status "{service}"', raise_on_error=raise_on_error
+            f'systemctl restart "{service}" || systemctl status "{service}"',
+            raise_on_error=raise_on_error,
+            log_level=SSHLog.Error,
         )
 
     def async_reload(self, service: str) -> SSHProcess:
@@ -137,7 +163,10 @@ class SystemdServices(MultihostUtility):
         :return: Running SSH process.
         :rtype: SSHProcess
         """
-        return self.host.ssh.async_run(f'systemctl reload "{service}" || systemctl status "{service}"')
+        self.logger.info(f'systemd: reloading "{service}" asynchronously')
+        return self.host.ssh.async_run(
+            f'systemctl reload "{service}" || systemctl status "{service}"', log_level=SSHLog.Error
+        )
 
     def reload(self, service: str, raise_on_error: bool = True) -> SSHProcessResult:
         """
@@ -153,8 +182,11 @@ class SystemdServices(MultihostUtility):
         :return: SSH process result.
         :rtype: SSHProcessResult
         """
+        self.logger.info(f'systemd: reloading "{service}"')
         return self.host.ssh.run(
-            f'systemctl reload "{service}" || systemctl status "{service}"', raise_on_error=raise_on_error
+            f'systemctl reload "{service}" || systemctl status "{service}"',
+            raise_on_error=raise_on_error,
+            log_level=SSHLog.Error,
         )
 
     def async_status(self, service: str) -> SSHProcess:
@@ -188,7 +220,8 @@ class SystemdServices(MultihostUtility):
         :return: Running SSH process.
         :rtype: SSHProcess
         """
-        return self.host.ssh.async_run("systemctl daemon-reload")
+        self.logger.info("systemd: reloading systemd daemon")
+        return self.host.ssh.async_run("systemctl daemon-reload", log_level=SSHLog.Error)
 
     def reload_daemon(self, raise_on_error: bool = True) -> SSHProcessResult:
         """

--- a/pytest_mh/utils/tc.py
+++ b/pytest_mh/utils/tc.py
@@ -72,13 +72,15 @@ class LinuxTrafficControl(MultihostUtility):
         :param time: Delay. Units can be specified; if not specified, the default is milliseconds.
         :type time: str | int
         """
-        ips = self.host.ssh.run(f"dig +short {hostname}", log_level=SSHLog.Error)
-        ip_list = ips.stdout.splitlines()
-
         if isinstance(time, int):
             time_unit = f"{time}ms"
         else:
             time_unit = time
+
+        self.logger.info(f"Adding network delay {time_unit} to {hostname}")
+
+        ips = self.host.ssh.run(f"dig +short {hostname}", log_level=SSHLog.Error)
+        ip_list = ips.stdout.splitlines()
 
         commands = "set -e\n"
         for interface in self.__interfaces:
@@ -103,6 +105,8 @@ class LinuxTrafficControl(MultihostUtility):
         :param hostname: Target hostname.
         :type hostname: str
         """
+        self.logger.info(f"Removing network delay to {hostname}")
+
         ips = self.host.ssh.run(f"dig +short {hostname}", log_level=SSHLog.Error)
         ip_list = ips.stdout.splitlines()
 


### PR DESCRIPTION
Each log message now looks like:

```
INFO     2023-11-14 14:31:27,646      client.test Writing file "/etc/sssd/sssd.conf"
```

This PR depends (first two commits) on https://github.com/next-actions/pytest-mh/pull/25