### PR TITLE
artifacts: add support for dynamic artifacts list

### DIFF
--- a/pytest_mh/_private/logging.py
+++ b/pytest_mh/_private/logging.py
@@ -219,7 +219,7 @@ class LogExtraDataFilter(logging.Filter):
 
             return out
 
-        if isinstance(o, list):
+        if isinstance(o, (list, set, tuple)):
             out = ""
             for value in o:
                 out += "\n- " + str(value)

--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -372,6 +372,16 @@ class MultihostHost(Generic[DomainType]):
         if not self.artifacts:
             return
 
+        self.logger.info(
+            "Collecting artifacts",
+            extra={
+                "data": {
+                    "Local destination": dest,
+                    "Artifacts": self.artifacts,
+                }
+            },
+        )
+
         # Create output directory
         Path(dest).mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Now roles, utils or individual tests can add custom artifacts to 
role.artifacts. This will be added to the list of host artifacts configured
in mhc.yaml.