### PR TITLE
mh: Remove spaces and brackets from log paths.

### DIFF
--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -266,8 +266,7 @@ class MultihostFixture(object):
             return None
 
         name = self.request.node.name
-        for c in list('":<>|*?'):
-            name = name.replace(c, "-")
+        name = name.translate(str.maketrans('":<>|*? [', "---------", "]()"))
 
         return f"{dir}/{name}"
 


### PR DESCRIPTION
Spaces in the test log path were causing  issues in artifact upload.