### PR TITLE
logs: do not create None directory

### DIFF
--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -305,8 +305,8 @@ class MultihostFixture(object):
         path = self._artifacts_dir()
         if path is None:
             self.logger.clear()
-
-        self.logger.write_to_file(f"{path}/test.log")
+        else:
+            self.logger.write_to_file(f"{path}/test.log")
 
     def log_phase(self, phase: str) -> None:
         """


### PR DESCRIPTION
We only want to write the log file if a destination path is set.

---

This can be reproduced e.g. by  setting `--mh-collect-artifacts=never`