### PR TITLE
artifacts: extract archive by default

### DIFF
--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -64,5 +64,6 @@ New pytest command line options
   artifacts are collected. Default value is ``on-failure`` - only collect
   artifacts if test fails.
 * ``--mh-artifacts-dir`` - Directory where test artifacts are stored.
+* ``--mh-compress-artifacts`` - If set, test artifacts are stored in a compressed archive.
 * ``--mh-topology`` - Filter tests by given topology, can be set multiple times.
 * ``--mh-not-topology`` - Do not run tests for given topology, can be set multiple times.

--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -100,6 +100,10 @@ class MultihostFixture(object):
         Available MultihostHost objects.
         """
 
+        self._opt_artifacts_dir: str = self.request.config.getoption("mh_artifacts_dir")
+        self._opt_artifacts_mode: str = self.request.config.getoption("mh_collect_artifacts")
+        self._opt_artifacts_compression: bool = self.request.config.getoption("mh_compress_artifacts")
+
         self._paths: dict[str, list[MultihostRole] | MultihostRole] = {}
         self._skipped: bool = False
 
@@ -270,8 +274,8 @@ class MultihostFixture(object):
         if self._skipped:
             return None
 
-        dir = self.request.config.getoption("mh_artifacts_dir")
-        mode = self.request.config.getoption("mh_collect_artifacts")
+        dir = self._opt_artifacts_dir
+        mode = self._opt_artifacts_mode
         if mode == "never" or (mode == "on-failure" and self.data.outcome != "failed"):
             return None
 
@@ -295,7 +299,7 @@ class MultihostFixture(object):
         if path is None:
             return
 
-        host.collect_artifacts(path, artifacts)
+        host.collect_artifacts(path, artifacts, self._opt_artifacts_compression)
 
     def _flush_logs(self) -> None:
         """

--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -441,6 +441,12 @@ def pytest_addoption(parser):
         help="Directory where artifacts will be stored (default: %(default)s)",
     )
 
+    parser.addoption(
+        "--mh-compress-artifacts",
+        action="store_true",
+        help="If set, test artifacts are stored in a compressed archive",
+    )
+
 
 def pytest_configure(config: pytest.Config):
     """


### PR DESCRIPTION
Artifacts are now extracted by default which is more convenient for
most use cases. For local run, you want to be able to quickly debug
failures and automation usually already compress everything in single
archive so it is again better to make it more easily accessible.

--mh-compress-artifacts was added to switch to the original behavior.