### PR TITLE
multihost: do not attempt to write artifacts if none were collected

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,12 @@
 pytest_mh - pytest multihost test framework
 ###########################################
 
+.. warning::
+
+    This plugin is still actively developed and even though it is mostly stable,
+    we reserve the right to introduce minor breaking changes if it is required for
+    new functionality.
+
 ``pytest-mh`` is a pytest plugin that, at a basic level, allows you to run shell
 commands and scripts over SSH on remote Linux or Windows hosts. You use it to
 execute system or application tests for your project on a remote host or hosts

--- a/pytest_mh/__init__.py
+++ b/pytest_mh/__init__.py
@@ -1,6 +1,7 @@
 """
 .. avoid already-imported warning: PYTEST_DONT_REWRITE (hidden from sphinx)
 """
+
 from __future__ import annotations
 
 from ._private.data import MultihostItemData

--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -411,6 +411,10 @@ class MultihostHost(Generic[DomainType]):
 
         result = self.ssh.run(command, log_level=SSHLog.Error)
 
+        # Return if no artifacts were obtained
+        if not result.stdout:
+            return
+
         name = f"{self.role}_{self.hostname}"
         with BytesIO(b64decode(result.stdout)) as buffer:
             if compression:

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> This plugin is still actively developed and even though it is mostly stable,
+> we reserve the right to introduce minor breaking changes if it is required for
+> new functionality.
+
 # pytest_mh - pytest multihost test framework
 
 `pytest-mh` is a pytest plugin that, at a basic level, allows you to run shell


### PR DESCRIPTION
We would either store empty tarball (which is unreadable by tar) or fail
to extract it if artifact list is not empty but at the same time the
required files do not exist on the host.