### PR TITLE
add topology controller

### DIFF
--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -165,7 +165,7 @@ fixtures.
 
     @pytest.mark.topology(
         "kdc", Topology(TopologyDomain("test", client=1, kdc=1)),
-        client="test.client[0]", kdc="test.kdc[0]"
+        fixtures=dict(client="test.client[0]", kdc="test.kdc[0]")
     )
     def test_example(client: Client, kdc: KDC):
         pass

--- a/docs/topology.rst
+++ b/docs/topology.rst
@@ -54,7 +54,7 @@ The marker is used as:
 
 .. code-block:: python
 
-    @pytest.mark.topology(name, topology, *, fixtures ...)
+    @pytest.mark.topology(name, topology, *, fixtures=dict(...))
     def test_example():
         assert True
 
@@ -179,7 +179,7 @@ The example above can be rewritten as:
 
     @pytest.mark.topology(
         'ldap', Topology(TopologyDomain('test', client=1, ldap=1)),
-        client='test.client[0]', ldap='test.ldap[0]'
+        fixtures=dict(client='test.client[0]', ldap='test.ldap[0]')
     )
     def test_example(client: Client, ldap: LDAP):
         assert client.role == 'client'
@@ -198,7 +198,7 @@ benefit from it.
 
     @pytest.mark.topology(
         'ldap', Topology(TopologyDomain('test', client=1, ldap=1)),
-        clients='test.client', ldap='test.ldap[0]'
+        fixtures=dict(clients='test.client', ldap='test.ldap[0]')
     )
     def test_example(clients: list[Client], ldap: LDAP):
         for client in clients:
@@ -217,7 +217,7 @@ benefit from it.
 
         @pytest.mark.topology(
             'ldap', Topology(TopologyDomain('test', client=1, ldap=1)),
-            clients='test.client'
+            fixtures=dict(clients='test.client')
         )
         def test_example(mh: MultihostFixture, clients: list[Client]):
             pass
@@ -231,7 +231,7 @@ benefit from it.
 
         @pytest.mark.topology(
             'ldap', Topology(TopologyDomain('test', client=1, ldap=1)),
-            client='test.client[0]', ldap='test.ldap[0]', provider='test.ldap[0]'
+            fixtures=dict(client='test.client[0]', ldap='test.ldap[0]', provider='test.ldap[0]')
         )
         def test_example(client: Client, provider: GenericProvider):
             pass

--- a/docs/topology.rst
+++ b/docs/topology.rst
@@ -114,8 +114,8 @@ domains (:class:`~pytest_mh.MultihostDomain`) and hosts (as
 
 To access the hosts through the :func:`~pytest_mh.mh` fixture use:
 
-* ``mh.<domain-id>.<role>`` to access a list of all hosts that implements given role
-* ``mh.<domain-id>.<role>[<index>]`` to access a specific host through index starting from 0
+* ``mh.ns.<domain-id>.<role>`` to access a list of all hosts that implements given role
+* ``mh.ns.<domain-id>.<role>[<index>]`` to access a specific host through index starting from 0
 
 The following snippet shows how to access hosts from our topology:
 
@@ -123,8 +123,8 @@ The following snippet shows how to access hosts from our topology:
 
     @pytest.mark.topology('ldap', Topology(TopologyDomain('test', client=1, ldap=1)))
     def test_example(mh: MultihostFixture):
-        assert mh.test.client[0].role == 'client'
-        assert mh.test.ldap[0].role == 'ldap'
+        assert mh.ns.test.client[0].role == 'client'
+        assert mh.ns.test.ldap[0].role == 'ldap'
 
 Since the role objects are instances of your own classes (``LDAP`` and
 ``Client`` for our example), you can also set the type to get the advantage of
@@ -134,8 +134,8 @@ Python type hinting.
 
     @pytest.mark.topology('ldap', Topology(TopologyDomain('test', client=1, ldap=1)))
     def test_example(mh: MultihostFixture):
-        client: Client = mh.test.client[0]
-        ldap: LDAP = mh.test.ldap[0]
+        client: Client = mh.ns.test.client[0]
+        ldap: LDAP = mh.ns.test.ldap[0]
 
         assert client.role == 'client'
         assert ldap.role == 'ldap'
@@ -143,8 +143,8 @@ Python type hinting.
 
     @pytest.mark.topology('ldap', Topology(TopologyDomain('test', client=1, ldap=1)))
     def test_example2(mh: MultihostFixture):
-        clients: list[Client] = mh.test.client
-        ldaps: list[LDAP] = mh.test.ldap
+        clients: list[Client] = mh.ns.test.client
+        ldaps: list[LDAP] = mh.ns.test.ldap
 
         for client in clients:
             assert client.role == 'client'

--- a/pytest_mh/__init__.py
+++ b/pytest_mh/__init__.py
@@ -17,6 +17,7 @@ from ._private.multihost import (
 )
 from ._private.plugin import MultihostPlugin, pytest_addoption, pytest_configure
 from ._private.topology import Topology, TopologyDomain
+from ._private.topology_controller import TopologyController
 
 __all__ = [
     "mh",
@@ -32,6 +33,7 @@ __all__ = [
     "pytest_addoption",
     "pytest_configure",
     "Topology",
+    "TopologyController",
     "TopologyDomain",
     "TopologyMark",
     "KnownTopologyBase",

--- a/pytest_mh/_private/data.py
+++ b/pytest_mh/_private/data.py
@@ -27,6 +27,21 @@ class MultihostItemData(object):
         Test run outcome, available in fixture finalizers.
         """
 
+    def _init(self) -> None:
+        """
+        Postponed initialization. This is called once we know that current
+        mh configuration supports desired topology.
+        """
+        # Initialize topology controller
+        if self.multihost is not None and self.topology_mark is not None:
+            self.topology_mark.controller._init(
+                self.topology_mark.name,
+                self.multihost,
+                self.multihost.logger,
+                self.topology_mark.topology,
+                self.topology_mark.fixtures,
+            )
+
     @staticmethod
     def SetData(item: pytest.Item, data: MultihostItemData | None) -> None:
         item.stash[DataStashKey] = data

--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -46,9 +46,9 @@ class MultihostFixture(object):
         :caption: Example of the MultihostFixture object
 
         def test_example(mh: MultihostFixture):
-            mh.test            # -> namespace containing roles as properties
-            mh.test.client     # -> list of hosts providing given role
-            mh.test.client[0]  # -> host object, instance of specific role
+            mh.ns.test            # -> namespace containing roles as properties
+            mh.ns.test.client     # -> list of hosts providing given role
+            mh.ns.test.client[0]  # -> host object, instance of specific role
     """
 
     def __init__(
@@ -100,6 +100,11 @@ class MultihostFixture(object):
         Available MultihostHost objects.
         """
 
+        self.ns: SimpleNamespace = SimpleNamespace()
+        """
+        Roles as object accessible through topology path, e.g. ``mh.ns.domain_id.role_name``.
+        """
+
         self._opt_artifacts_dir: str = self.request.config.getoption("mh_artifacts_dir")
         self._opt_artifacts_mode: str = self.request.config.getoption("mh_collect_artifacts")
         self._opt_artifacts_compression: bool = self.request.config.getoption("mh_compress_artifacts")
@@ -109,7 +114,7 @@ class MultihostFixture(object):
 
         for domain in self.multihost.domains:
             if domain.id in topology:
-                setattr(self, domain.id, self._domain_to_namespace(domain, topology.get(domain.id)))
+                setattr(self.ns, domain.id, self._domain_to_namespace(domain, topology.get(domain.id)))
 
         self.roles = sorted([x for x in self._paths.values() if isinstance(x, MultihostRole)], key=lambda x: x.role)
         self.hosts = sorted(list({x.host for x in self.roles}), key=lambda x: x.hostname)

--- a/pytest_mh/_private/marks.py
+++ b/pytest_mh/_private/marks.py
@@ -21,7 +21,7 @@ class TopologyMark(object):
     .. code-block:: python
         :caption: Example usage
 
-        @pytest.mark.topology(name, topology, fixture1='path1', fixture2='path2', ...)
+        @pytest.mark.topology(name, topology, fixture=dict(fixture1='path1', fixture2='path2', ...))
         def test_fixture_name(fixture1: BaseRole, fixture2: BaseRole, ...):
             assert True
 
@@ -40,6 +40,7 @@ class TopologyMark(object):
         self,
         name: str,
         topology: Topology,
+        *,
         fixtures: dict[str, str] | None = None,
     ) -> None:
         """
@@ -176,7 +177,7 @@ class TopologyMark(object):
         :return: Instance of TopologyMark.
         :rtype: TopologyMark
         """
-        # First three parameters are positional, the rest are keyword arguments.
+        # First two parameters are positional, the rest are keyword arguments.
         if len(args) != 2:
             nodeid = item.parent.nodeid if item.parent is not None else ""
             error = f"{nodeid}::{item.originalname}: invalid arguments for @pytest.mark.topology"
@@ -184,9 +185,9 @@ class TopologyMark(object):
 
         name = args[0]
         topology = args[1]
-        fixtures = {k: str(v) for k, v in kwargs.items()}
+        fixtures = {k: str(v) for k, v in kwargs.get("fixtures", {}).items()}
 
-        return cls(name, topology, fixtures)
+        return cls(name, topology, fixtures=fixtures)
 
 
 class KnownTopologyBase(Enum):

--- a/pytest_mh/_private/marks.py
+++ b/pytest_mh/_private/marks.py
@@ -151,9 +151,10 @@ class TopologyMark(object):
         :raises ValueError:
         :rtype: TopologyMark
         """
+        nodeid = item.parent.nodeid if item.parent is not None else ""
+        error = f"{nodeid}::{item.originalname}: invalid arguments for @pytest.mark.topology"
+
         if not mark.args or len(mark.args) > 3:
-            nodeid = item.parent.nodeid if item.parent is not None else ""
-            error = f"{nodeid}::{item.originalname}: invalid arguments for @pytest.mark.topology"
             raise ValueError(error)
 
         # Constructor for KnownTopologyBase

--- a/pytest_mh/_private/misc.py
+++ b/pytest_mh/_private/misc.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 from copy import deepcopy
 from functools import partial
 from inspect import getfullargspec
-from typing import Any, Callable
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, Callable
+
+from .topology import Topology, TopologyDomain
+
+if TYPE_CHECKING:
+    from .multihost import MultihostConfig, MultihostDomain, MultihostHost
 
 
 def merge_dict(*args: dict | None):
@@ -68,3 +74,90 @@ def invoke_callback(cb: Callable, /, **kwargs: Any) -> Any:
         callspec = kwargs
 
     return cb(**callspec)
+
+
+def topology_domain_to_host_namespace(
+    topology_domain: TopologyDomain, mh_domain: MultihostDomain
+) -> tuple[SimpleNamespace, dict[str, MultihostHost | list[MultihostHost]]]:
+    """
+    Convert topology domain into a namespace of MultihostHost objects accessible
+    by roles names.
+
+    :param topology_domain: Topology domain.
+    :type topology_domain: TopologyDomain
+    :param mh_domain: MultihostDomain
+    :type mh_domain: MultihostDomain
+    :return: Pair of namespace and path to host mapping.
+    :rtype: tuple[SimpleNamespace, dict[str, MultihostHost | list[MultihostHost]]]
+    """
+    ns = SimpleNamespace()
+    paths: dict[str, MultihostHost | list[MultihostHost]] = {}
+
+    for role_name in mh_domain.roles:
+        if role_name not in topology_domain:
+            continue
+
+        count = topology_domain.get(role_name)
+        hosts = [host for host in mh_domain.hosts_by_role(role_name)[:count]]
+        setattr(ns, role_name, hosts)
+
+        paths[f"{topology_domain.id}.{role_name}"] = hosts
+        for index, host in enumerate(hosts):
+            paths[f"{topology_domain.id}.{role_name}[{index}]"] = host
+
+    return (ns, paths)
+
+
+def topology_to_host_namespace(
+    topology: Topology, mh_domains: list[MultihostDomain]
+) -> tuple[SimpleNamespace, dict[str, MultihostHost | list[MultihostHost]]]:
+    """
+    Convert topology into a namespace of MultihostHost objects accessible
+    by domain id and roles names.
+
+    :param topology: Topology.
+    :type topology: Topology
+    :param mh_domains: List of MultihostDomain
+    :type mh_domains: list[MultihostDomain]
+    :return: Pair of namespace and path to host mapping.
+    :rtype: tuple[SimpleNamespace, dict[str, MultihostHost | list[MultihostHost]]]
+    """
+    root = SimpleNamespace()
+    paths: dict[str, MultihostHost | list[MultihostHost]] = {}
+
+    for mh_domain in mh_domains:
+        if mh_domain.id in topology:
+            ns, nspaths = topology_domain_to_host_namespace(topology.get(mh_domain.id), mh_domain)
+            setattr(root, mh_domain.id, ns)
+            paths.update(**nspaths)
+
+    return root, paths
+
+
+def topology_controller_parameters(
+    mh_config: MultihostConfig, topology: Topology, fixtures: dict[str, str]
+) -> dict[str, Any]:
+    """
+    Create dictionary of parameters for topology controller hooks.
+
+    :param mh_config: MultihostConfig object.
+    :type mh_config: MultihostConfig
+    :param topology: Topology.
+    :type topology: Topology
+    :param fixtures: Topology fixtures.
+    :type fixtures: dict[str, str]
+    :return: Parameters.
+    :rtype: dict[str, Any]
+    """
+    ns, paths = topology_to_host_namespace(topology, mh_config.domains)
+
+    args = {}
+    for name, path in fixtures.items():
+        args[name] = paths[path]
+
+    return {
+        "mhc": mh_config,
+        "logger": mh_config.logger,
+        "ns": ns,
+        **args,
+    }

--- a/pytest_mh/_private/misc.py
+++ b/pytest_mh/_private/misc.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from functools import partial
+from inspect import getfullargspec
+from typing import Any, Callable
 
 
 def merge_dict(d1, d2):
@@ -18,3 +21,44 @@ def merge_dict(d1, d2):
         dest[key] = value
 
     return dest
+
+
+def invoke_callback(cb: Callable, /, **kwargs: Any) -> Any:
+    """
+    Invoke callback with given arguments.
+
+    The callback may take all or only selected subset of given arguments.
+
+    :param cb: Callback to call.
+    :type cb: Callable
+    :param `*kwargs`: Callback parameters.
+    :type `*kwargs`: dict[str, Any]
+    :param
+    :return: Return value of the callabck.
+    :rtype: Any
+    """
+    cb_args: list[str] = []
+
+    # Get list of parameters required by the callback
+    if isinstance(cb, partial):
+        spec = getfullargspec(cb.func)
+
+        cb_args = spec.args + spec.kwonlyargs
+
+        # Remove bound positional parameters
+        cb_args = cb_args[len(cb.args) :]
+
+        # Remove bound keyword parameters
+        cb_args = [x for x in cb_args if x not in cb.keywords]
+    else:
+        spec = getfullargspec(cb)
+        cb_args = spec.args + spec.kwonlyargs
+
+    if spec.varkw is None:
+        # No **kwargs is present, just pick selected arguments
+        callspec = {k: v for k, v in kwargs.items() if k in cb_args}
+    else:
+        # **kwargs is present, pass everything
+        callspec = kwargs
+
+    return cb(**callspec)

--- a/pytest_mh/_private/misc.py
+++ b/pytest_mh/_private/misc.py
@@ -6,19 +6,25 @@ from inspect import getfullargspec
 from typing import Any, Callable
 
 
-def merge_dict(d1, d2):
+def merge_dict(*args: dict | None):
     """
-    Merge two nested dictionaries together.
+    Merge two or more nested dictionaries together.
 
     Nested dictionaries are not overwritten but combined.
     """
-    dest = deepcopy(d1)
-    for key, value in d2.items():
-        if isinstance(value, dict):
-            dest[key] = merge_dict(dest.get(key, {}), value)
-            continue
+    filtered_args = [x for x in args if x is not None]
+    if not filtered_args:
+        return {}
 
-        dest[key] = value
+    dest = deepcopy(filtered_args[0])
+
+    for source in filtered_args[1:]:
+        for key, value in source.items():
+            if isinstance(value, dict):
+                dest[key] = merge_dict(dest.get(key, {}), value)
+                continue
+
+            dest[key] = value
 
     return dest
 

--- a/pytest_mh/_private/topology_controller.py
+++ b/pytest_mh/_private/topology_controller.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, Callable
+
+from .logging import MultihostLogger
+from .misc import invoke_callback
+from .topology import Topology, TopologyDomain
+
+if TYPE_CHECKING:
+    from .multihost import MultihostConfig, MultihostDomain, MultihostHost
+
+
+class TopologyController(object):
+    """
+    Topology controller can be associated with a topology via TopologyMark
+    to provide additional per-topology hooks such as per-topology setup
+    and teardown.
+
+    When inheriting from this class, keep it mind that there is postpone
+    initialization of all present properties therefore you can not access
+    them inside the constructor. The properties are initialized a test is
+    collected.
+
+    Each method can take MultihostHost object as parameters as defined in
+    topology fixtures.
+
+    .. code-block:: python
+        :caption: Example topology controller
+
+        class ExampleController(TopologyController):
+            def skip(self, client: ClientHost) -> str | None:
+                result = client.ssh.run(
+                    '''
+                    # Implement your requirement check here
+                    exit 1
+                    ''', raise_on_error=False)
+                if result.rc != 0:
+                    return "Topology requirements were not met"
+
+                return None
+
+            def topology_setup(self, client: ClientHost):
+                # One-time setup, prepare the host for this topology
+                # Changes done here are shared for all tests
+                pass
+
+            def topology_teardown(self, client: ClientHost):
+                # One-time teardown, this should undo changes from
+                # topology_setup
+                pass
+
+            def setup(self, client: ClientHost):
+                # Perform per-topology test setup
+                # This is called before execution of every test
+                pass
+
+            def teardown(self, client: ClientHost):
+                # Perform per-topology test teardown, this should undo changes
+                # from setup
+                pass
+
+    .. code-block:: python
+        :caption: Example with low-level topology mark
+
+        class ExampleController(TopologyController):
+            # Implement methods you are interested in here
+            pass
+
+        @pytest.mark.topology(
+            "example", Topology(TopologyDomain("example", client=1)),
+            controller=ExampleController(),
+            fixtures=dict(client="example.client[0]")
+        )
+        def test_example(client: Client):
+            pass
+
+    .. code-block:: python
+        :caption: Example with KnownTopology
+
+        class ExampleController(TopologyController):
+            # Implement methods you are interested in here
+            pass
+
+        @final
+        @unique
+        class KnownTopology(KnownTopologyBase):
+            EXAMPLE = TopologyMark(
+                name='example',
+                topology=Topology(TopologyDomain("example", client=1)),
+                controller=ExampleController(),
+                fixtures=dict(client='example.client[0]'),
+            )
+
+        @pytest.mark.topology(KnownTopology.EXAMPLE)
+        def test_example(client: Client):
+            pass
+    """
+
+    def __init__(self) -> None:
+        self.__name: str | None = None
+        self.__multihost: MultihostConfig | None = None
+        self.__logger: MultihostLogger | None = None
+        self.__topology: Topology | None = None
+        self.__ns: SimpleNamespace | None = None
+        self.__args: dict[str, MultihostHost | list[MultihostHost]] | None = None
+        self.__initialized: bool = False
+
+    def _init(
+        self,
+        name: str,
+        multihost: MultihostConfig,
+        logger: MultihostLogger,
+        topology: Topology,
+        mapping: dict[str, str],
+    ):
+        # This is called for each testcase but the controller may be shared with
+        # multiple testcases therefore we want to avoid multiple initialization.
+        if self.__initialized:
+            return
+
+        self.__name = name
+        self.__multihost = multihost
+        self.__logger = logger
+        self.__topology = topology
+        self.__ns, self.__args = self._build_namespace_and_args(multihost.domains, topology, mapping)
+
+        self.__initialized = True
+
+    def _build_namespace_and_args(
+        self,
+        mh_domains: list[MultihostDomain],
+        topology: Topology,
+        mapping: dict[str, str],
+    ) -> tuple[SimpleNamespace, dict[str, MultihostHost | list[MultihostHost]]]:
+        root = SimpleNamespace()
+        paths: dict[str, MultihostHost | list[MultihostHost]] = {}
+
+        for mh_domain in mh_domains:
+            if mh_domain.id in topology:
+                ns, nspaths = self._build_domain_namespace_and_paths(topology.get(mh_domain.id), mh_domain)
+                setattr(root, mh_domain.id, ns)
+                paths.update(**nspaths)
+
+        args = {}
+        for name, path in mapping.items():
+            args[name] = paths[path]
+
+        return (root, args)
+
+    def _build_domain_namespace_and_paths(
+        self,
+        topology_domain: TopologyDomain,
+        mh_domain: MultihostDomain,
+    ) -> tuple[SimpleNamespace, dict[str, MultihostHost | list[MultihostHost]]]:
+        ns = SimpleNamespace()
+        paths: dict[str, MultihostHost | list[MultihostHost]] = {}
+
+        for role_name in mh_domain.roles:
+            if role_name not in topology_domain:
+                continue
+
+            count = topology_domain.get(role_name)
+            hosts = [host for host in mh_domain.hosts_by_role(role_name)[:count]]
+            setattr(ns, role_name, hosts)
+
+            paths[f"{topology_domain.id}.{role_name}"] = hosts
+            for index, host in enumerate(hosts):
+                paths[f"{topology_domain.id}.{role_name}[{index}]"] = host
+
+        return (ns, paths)
+
+    def _invoke_with_args(self, cb: Callable) -> Any:
+        if self.__args is None:
+            raise RuntimeError("TopologyController has not been initialized yet")
+
+        return invoke_callback(cb, **self.__args)
+
+    @property
+    def name(self) -> str:
+        """
+        Topology name.
+
+        This property cannot be accessed from the constructor.
+
+        :return: Topology name.
+        :rtype: str
+        """
+        if self.__name is None:
+            raise RuntimeError("TopologyController has not been initialized yet")
+
+        return self.__name
+
+    @property
+    def topology(self) -> Topology:
+        """
+        Multihost topology.
+
+        This property cannot be accessed from the constructor.
+
+        :return: Topology.
+        :rtype: Topology
+        """
+        if self.__topology is None:
+            raise RuntimeError("TopologyController has not been initialized yet")
+
+        return self.__topology
+
+    @property
+    def multihost(self) -> MultihostConfig:
+        """
+        Multihost configuration.
+
+        This property cannot be accessed from the constructor.
+
+        :return: Multihost configuration.
+        :rtype: MultihostConfig
+        """
+        if self.__multihost is None:
+            raise RuntimeError("TopologyController has not been initialized yet")
+
+        return self.__multihost
+
+    @property
+    def logger(self) -> MultihostLogger:
+        """
+        Multihost logger.
+
+        This property cannot be accessed from the constructor.
+
+        :return: Multihost logger.
+        :rtype: MultihostLogger
+        """
+        if self.__logger is None:
+            raise RuntimeError("TopologyController has not been initialized yet")
+
+        return self.__logger
+
+    @property
+    def ns(self) -> SimpleNamespace:
+        """
+        Namespace of MultihostHost objects accessible by domain id and roles names.
+
+        This property cannot be accessed from the constructor.
+
+        :return: Namespace.
+        :rtype: SimpleNamespace
+        """
+        if self.__ns is None:
+            raise RuntimeError("TopologyController has not been initialized yet")
+
+        return self.__ns
+
+    def skip(self) -> str | None:
+        """
+        Called before a test is executed.
+
+        If a non-None value is returned the test is skipped, using the returned
+        value as a skip reason.
+
+        :rtype: str | None
+        """
+        return None
+
+    def topology_setup(self) -> None:
+        """
+        Called once before executing the first test of given topology.
+        """
+        pass
+
+    def topology_teardown(self) -> None:
+        """
+        Called once after all tests for given topology were run.
+        """
+        pass
+
+    def setup(self) -> None:
+        """
+        Called before execution of each test.
+        """
+        pass
+
+    def teardown(self) -> None:
+        """
+        Called after execution of each test.
+        """
+        pass

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2,7 +2,75 @@ from __future__ import annotations
 
 from functools import partial
 
-from pytest_mh._private.misc import invoke_callback
+import pytest
+
+from pytest_mh._private.misc import invoke_callback, merge_dict
+
+
+@pytest.mark.parametrize(
+    "dicts, expected",
+    [
+        ([None], dict()),
+        ([dict()], dict()),
+        ([None, None], dict()),
+        ([dict(), dict()], dict()),
+        ([dict(), dict(), dict()], dict()),
+        ([None, dict(a="a", b="b")], dict(a="a", b="b")),
+        ([None, dict(a="a", b="b")], dict(a="a", b="b")),
+        ([dict(a="a", b="b"), None], dict(a="a", b="b")),
+        ([dict(), dict(a="a", b="b")], dict(a="a", b="b")),
+        ([dict(a="a", b="b"), dict()], dict(a="a", b="b")),
+        ([dict(a="a"), dict(b="b"), dict(c="c")], dict(a="a", b="b", c="c")),
+        ([dict(a="a", b="b"), dict(c="c")], dict(a="a", b="b", c="c")),
+        (
+            [
+                dict(a="a", b=dict(bb="bb")),
+                dict(c="c"),
+            ],
+            dict(a="a", b=dict(bb="bb"), c="c"),
+        ),
+        (
+            [
+                dict(a="a", b=dict(bb="bb")),
+                dict(b="b"),
+            ],
+            dict(a="a", b="b"),
+        ),
+        (
+            [
+                dict(a="a", b=dict(bb="bb")),
+                dict(b=dict(bb="1")),
+            ],
+            dict(a="a", b=dict(bb="1")),
+        ),
+        (
+            [
+                dict(a="a", b=dict(bb="bb")),
+                dict(b=dict(bc="bc")),
+            ],
+            dict(a="a", b=dict(bb="bb", bc="bc")),
+        ),
+        (
+            [
+                dict(a="a", b=dict(bb="bb")),
+                dict(b=dict(bc="bc")),
+                dict(b=dict(bd="bd")),
+            ],
+            dict(a="a", b=dict(bb="bb", bc="bc", bd="bd")),
+        ),
+        (
+            [
+                dict(a="a", b=dict(bb=dict(bbb="bbb"))),
+                dict(b=dict(bc="bc")),
+                dict(b=dict(bb=dict(bbc="bbc"))),
+            ],
+            dict(a="a", b=dict(bb=dict(bbb="bbb", bbc="bbc"), bc="bc")),
+        ),
+    ],
+)
+def test_merge_dict(dicts, expected):
+    result = merge_dict(*dicts)
+    assert result == expected
 
 
 def test_invoke_callback__exact():

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from functools import partial
+
+from pytest_mh._private.misc import invoke_callback
+
+
+def test_invoke_callback__exact():
+    def _cb(a, b, c) -> None:
+        assert a == 1
+        assert b == 2
+        assert c == 3
+
+    invoke_callback(_cb, a=1, b=2, c=3)
+    invoke_callback(partial(_cb, 1), b=2, c=3)
+    invoke_callback(partial(_cb, 1, 2), c=3)
+    invoke_callback(partial(_cb, a=1), b=2, c=3)
+
+
+def test_invoke_callback__subset():
+    def _cb(a, b, c) -> None:
+        assert a == 1
+        assert b == 2
+        assert c == 3
+
+    invoke_callback(_cb, a=1, b=2, c=3, d=4, e=5)
+    invoke_callback(partial(_cb, 1), b=2, c=3, d=4, e=5)
+    invoke_callback(partial(_cb, 1, 2), c=3, d=4, e=5)
+    invoke_callback(partial(_cb, a=1), b=2, c=3, d=4, e=5)
+
+
+def test_invoke_callback__kwonly():
+    def _cb(a, *, b, c) -> None:
+        assert a == 1
+        assert b == 2
+        assert c == 3
+
+    invoke_callback(_cb, a=1, b=2, c=3)
+    invoke_callback(partial(_cb, 1), b=2, c=3)
+    invoke_callback(partial(_cb, a=1), b=2, c=3)
+    invoke_callback(partial(_cb, b=2), a=1, c=3)
+
+
+def test_invoke_callback__kwargs():
+    def _cb(**kwargs) -> None:
+        assert kwargs["a"] == 1
+        assert kwargs["b"] == 2
+        assert kwargs["c"] == 3
+
+    invoke_callback(_cb, a=1, b=2, c=3)
+    invoke_callback(partial(_cb, a=1), b=2, c=3)
+    invoke_callback(partial(_cb, b=2), a=1, c=3)
+    invoke_callback(partial(_cb, b=2, c=3), a=1)
+
+
+def test_invoke_callback__kwargs_mixed():
+    def _cb(d, **kwargs) -> None:
+        assert kwargs["a"] == 1
+        assert kwargs["b"] == 2
+        assert kwargs["c"] == 3
+        assert d == 4
+
+    invoke_callback(_cb, a=1, b=2, c=3, d=4)
+    invoke_callback(partial(_cb, 4), a=1, b=2, c=3)
+    invoke_callback(partial(_cb, a=1), b=2, c=3, d=4)
+    invoke_callback(partial(_cb, d=4), a=1, b=2, c=3)


### PR DESCRIPTION
Topology controller can provide various topology related hooks.
Right now, it provides per-topology setup and teardown as well
as the possibility to skip all tests for this topology.

We can use it to automatically enroll client into domains or
setup trust. Doing this in ansible has its limitations for more
complex setups (such as multiple AD domains). Now we can do it
from pytest so we don't have to run the test suite multiple times,
each time with different environment.