### PR TITLE
Produce better logs and collect artifacts on failed setup

### DIFF
--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -222,9 +222,6 @@ class MultihostFixture(object):
         """
         Run per-test setup from topology controller.
         """
-        if self._skipped:
-            return
-
         self.topology_controller._invoke_with_args(self.topology_controller.setup)
         self.topology_controller._op_state.set_success("setup")
 
@@ -232,9 +229,6 @@ class MultihostFixture(object):
         """
         Run per-test teardown from topology controller.
         """
-        if self._skipped:
-            return
-
         if self.topology_controller._op_state.check_success("setup"):
             self.topology_controller._invoke_with_args(self.topology_controller.teardown)
 
@@ -243,9 +237,6 @@ class MultihostFixture(object):
         Setup multihost. A setup method is called on each host and role
         to initialize the test environment to expected state.
         """
-        if self._skipped:
-            return
-
         for item in self.hosts + self.roles:
             item.setup()
             item._op_state.set_success("setup")
@@ -256,9 +247,6 @@ class MultihostFixture(object):
         that were made during a test run. It is automatically called when the
         test is finished.
         """
-        if self._skipped:
-            return
-
         # Create list of dynamically added artifacts
         additional_artifacts: dict[MultihostHost, list[str]] = {}
         for role in self.roles:
@@ -377,6 +365,9 @@ class MultihostFixture(object):
         return self
 
     def _exit(self) -> None:
+        if self._skipped:
+            return
+
         errors: list[Exception | None] = []
         errors.append(self._invoke_phase("TEARDOWN TEST", self._teardown, catch=True))
         errors.append(self._invoke_phase("TEARDOWN TOPOLOGY", self._topology_teardown, catch=True))

--- a/pytest_mh/_private/misc.py
+++ b/pytest_mh/_private/misc.py
@@ -161,3 +161,83 @@ def topology_controller_parameters(
         "ns": ns,
         **args,
     }
+
+
+class OperationStatus(object):
+    """
+    Keep named states of operation.
+
+    This can be used to mark certain operations as completed with success,
+    failure or any other state and act later upon it.
+    """
+
+    def __init__(self) -> None:
+        self.states: dict[str, str] = {}
+
+    def set(self, name: str, state: str) -> None:
+        """
+        Set current state of the operation.
+
+        :param name: Operation name.
+        :type name: str
+        :param state: Current state.
+        :type state: str
+        """
+        self.states[name] = state
+
+    def set_success(self, name: str) -> None:
+        """
+        Mark operation as successful.
+
+        :param name: Operation name.
+        :type name: str
+        """
+        self.set(name, "success")
+
+    def set_failure(self, name: str) -> None:
+        """
+        Mark operation as failed.
+
+        :param name: Operation name.
+        :type name: str
+        """
+        self.set(name, "failure")
+
+    def check(self, name: str, expected_state: str) -> bool:
+        """
+        Check operation state.
+
+        :param name: Operation name.
+        :type name: str
+        :param expected_state: Expected state.
+        :type expected_state: str
+        :return: True if current state equals to the expected state, False otherwise.
+        :rtype: bool
+        """
+        state = self.states.get(name, None)
+        if state is None:
+            return False
+
+        return state == expected_state
+
+    def check_success(self, name: str) -> bool:
+        """
+        Check if operation state is success.
+
+        :param name: Operation name.
+        :type name: str
+        :return: True if current state equals to ``success``, False otherwise.
+        :rtype: bool
+        """
+        return self.check(name, "success")
+
+    def check_failure(self, name: str) -> bool:
+        """
+        Check if operation state is failure.
+
+        :param name: Operation name.
+        :type name: str
+        :return: True if current state equals to ``failure``, False otherwise.
+        :rtype: bool
+        """
+        return self.check(name, "failure")

--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -14,6 +14,7 @@ from ..cli import CLIBuilder
 from ..ssh import SSHBashProcess, SSHClient, SSHLog, SSHPowerShellProcess, SSHProcess
 from .logging import MultihostHostLogger, MultihostLogger
 from .marks import TopologyMark
+from .misc import OperationStatus
 from .utils import validate_configuration
 
 if TYPE_CHECKING:
@@ -271,6 +272,9 @@ class MultihostHost(Generic[DomainType]):
         :param shell: Shell used in SSH connection, defaults to '/usr/bin/bash -c'.
         :type shell: str
         """
+        self._op_state: OperationStatus = OperationStatus()
+        """Keep state of setup and teardown methods."""
+
         validate_configuration(
             self.required_fields, confdict, error_fmt='"{key}" property is missing in host configuration'
         )
@@ -469,6 +473,9 @@ class MultihostRole(Generic[HostType]):
         role: str,
         host: HostType,
     ) -> None:
+        self._op_state: OperationStatus = OperationStatus()
+        """Keep state of setup and teardown methods."""
+
         self.mh: MultihostFixture = mh
         self.role: str = role
         self.host: HostType = host

--- a/pytest_mh/_private/topology_controller.py
+++ b/pytest_mh/_private/topology_controller.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Callable
 
 from .logging import MultihostLogger
-from .misc import invoke_callback
+from .misc import OperationStatus, invoke_callback
 from .topology import Topology, TopologyDomain
 
 if TYPE_CHECKING:
@@ -98,6 +98,9 @@ class TopologyController(object):
     """
 
     def __init__(self) -> None:
+        self._op_state: OperationStatus = OperationStatus()
+        """Keep state of setup and teardown methods."""
+
         self.__name: str | None = None
         self.__multihost: MultihostConfig | None = None
         self.__logger: MultihostLogger | None = None

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4,7 +4,7 @@ from functools import partial
 
 import pytest
 
-from pytest_mh._private.misc import invoke_callback, merge_dict
+from pytest_mh._private.misc import OperationStatus, invoke_callback, merge_dict
 
 
 @pytest.mark.parametrize(
@@ -132,3 +132,20 @@ def test_invoke_callback__kwargs_mixed():
     invoke_callback(partial(_cb, 4), a=1, b=2, c=3)
     invoke_callback(partial(_cb, a=1), b=2, c=3, d=4)
     invoke_callback(partial(_cb, d=4), a=1, b=2, c=3)
+
+
+def test_OperationStatus():
+    op = OperationStatus()
+    op.set("example", "in-progress")
+    op.set_success("setup")
+    op.set_failure("teardown")
+
+    assert op.check("example", "in-progress")
+    assert not op.check("example", "success")
+    assert not op.check("missing", "success")
+
+    assert op.check_success("setup")
+    assert not op.check_success("teardown")
+
+    assert op.check_failure("teardown")
+    assert not op.check_failure("setup")


### PR DESCRIPTION
Before we did not collect any artifacts and logged teardown to a setup phase if an exception was risen during setup.

Now, setup and teardown are fully separated which makes the code easier and it is also separated in the logs. Additionally, we now collect available artifacts so we can actually learn why the setup phase failed.