### PR TITLE
ci: split tox package installation from testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox tox-gh
-    - name: Run tox
-      run: tox --colored=yes
+    - name: Prepare tox environment and install packages
+      run: |
+        tox --colored=yes --notest
+    - name: Run tests
+      run: |
+        tox --colored=yes --skip-pkg-install
 
   example:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This makes it clear if there is issue in tests or dependency
installation.