### PR TITLE
mh: support extra artifacts in host and utility as well

### DIFF
--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -244,6 +244,7 @@ class MultihostFixture(object):
     def _collect_artifacts(self) -> None:
         path = self._artifacts_dir()
         if path is None:
+            self.logger.info("Artifacts are not collected")
             return
 
         errors = []

--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -244,7 +244,6 @@ class MultihostFixture(object):
     def _collect_artifacts(self) -> None:
         path = self._artifacts_dir()
         if path is None:
-            self.logger.info("Artifacts are not collected")
             return
 
         errors = []

--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -410,7 +410,7 @@ class MultihostHost(Generic[DomainType]):
             case MultihostHostOSFamily.Linux:
                 command = f"""
                     tmp=`mktemp /tmp/mh.host.artifacts.XXXXXXXXX`
-                    tar -czvf "$tmp" {' '.join([f'$(compgen -G "{x}")' for x in artifacts])} &> /dev/null
+                    tar -hczvf "$tmp" {' '.join([f'$(compgen -G "{x}")' for x in artifacts])} &> /dev/null
                     base64 "$tmp"
                     rm -f "$tmp" &> /dev/null
                 """

--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -390,6 +390,7 @@ class MultihostHost(Generic[DomainType]):
         """
         artifacts = sorted(list(set(self.configured_artifacts + self.artifacts + additional_artifacts)))
         if not artifacts:
+            self.logger.info("No artifacts to collect.")
             return
 
         self.logger.info(


### PR DESCRIPTION
For example, if we have SSSDUtils, we can automatically make it
to collect SSSD logs and database instead of relying on configuration
in mhc.yaml.

Additionally, it is possible to use prepare_artifacts to collect coredumps
from coredumpclt/journald and other stuff.