### PR TITLE
fs: make write and restore work for files that are mounted in container

### DIFF
--- a/pytest_mh/utils/fs.py
+++ b/pytest_mh/utils/fs.py
@@ -518,7 +518,7 @@ class LinuxFileSystem(MultihostUtility):
         if [ -f '{path}' ]; then
             tmp=`mktemp /tmp/mh.fs.rollback.XXXXXXXXX`
             cp --force --archive '{path}' "$tmp"
-            echo "mv --force '$tmp' '{path}'"
+            echo "cp --force --archive '$tmp' '{path}' && rm --force '$tmp'"
         elif [ -d '{path}' ]; then
             tmp=`mktemp -d /tmp/mh.fs.rollback.XXXXXXXXX`
             cp --force --archive '{path}/.' "$tmp"

--- a/pytest_mh/utils/fs.py
+++ b/pytest_mh/utils/fs.py
@@ -232,7 +232,11 @@ class LinuxFileSystem(MultihostUtility):
         self.host.ssh.run(
             f"""
                 set -ex
-                rm -fr '{path}'
+
+                if [ -d '{path}' ]; then
+                  rm -fr '{path}'
+                fi
+
                 cat > '{path}'
                 {self.__gen_chattrs(path, mode=mode, user=user, group=group)}
             """,
@@ -399,7 +403,11 @@ class LinuxFileSystem(MultihostUtility):
         self.host.ssh.run(
             f"""
                 set -ex
-                rm -fr '{remote_path}'
+
+                if [ -d '{remote_path}' ]; then
+                  rm -fr '{remote_path}'
+                fi
+
                 base64 --decode > '{remote_path}'
                 {self.__gen_chattrs(remote_path, mode=mode, user=user, group=group)}
             """,


### PR DESCRIPTION
fs: switch to cp instead of mv in backup/restore

   This workaround a problem of restoring files that are mounted in containers
   like /etc/resolv.conf.

   fs: remove path only if it is directory for write and upload

   To keep file's attributes unless we want to explicitly overwrite them. This
   also helps on container's special files that are mounted and cannot be
   removed like /etc/resolv.conf.