### PR TITLE
Gather artifacts from host and topology setup and teardown and reorganize logs

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -136,3 +136,27 @@ artifacts with a possible wildcard character. For example:
       - /etc/sssd/*
       - /var/log/sssd/*
       - /var/lib/sss/db/*
+
+It is also possible to gather artifacts from
+:meth:`pytest_mh.MultihostHost.pytest_setup` and
+:meth:`pytest_mh.MultihostHost.pytest_teardown` calls. To do that, you need to
+provide artifacts as dictionary with ``pytest_setup``, ``pytest_teardown`` and
+``test`` keys.
+
+
+.. code-block:: yaml
+
+  - hostname: client.test
+    role: client
+    ssh:
+      host: 192.168.100.10
+      user: root
+      password: MySecret123
+    config:
+      artifacts:
+        pytest_setup:
+        - /var/log/host_setup.log
+        pytest_teardown:
+        - /var/log/host_teardown.log
+        test:
+        - /var/log/testrun.log

--- a/docs/pytest.rst
+++ b/docs/pytest.rst
@@ -67,3 +67,5 @@ New pytest command line options
 * ``--mh-compress-artifacts`` - If set, test artifacts are stored in a compressed archive.
 * ``--mh-topology`` - Filter tests by given topology, can be set multiple times.
 * ``--mh-not-topology`` - Do not run tests for given topology, can be set multiple times.
+* ``--mh-collect-logs=always|on-failure|never`` - Specifies when logs are
+  collected. Uses ``--mh-collect-artifacts`` as default value.

--- a/docs/runtime-requirements.rst
+++ b/docs/runtime-requirements.rst
@@ -40,6 +40,23 @@ The function takes all fixtures that are available to the test as parameters.
     def test_example_kwargs(client: Client, ldap: LDAP):
         pass
 
+It is also possible to pass a function directly instead of an anonymous (lambda)
+function if the requirement is shared between multiple tests. However, there is
+a documented glitch in pytest that requires you to use different marker syntax.
+See `pytest documentation
+<https://docs.pytest.org/en/stable/example/markers.html#passing-a-callable-to-custom-markers>`__
+for more information.
+
+.. code-block:: python
+
+    def require_files_provider(client: Client):
+        return "files-provider" in client.features, "SSSD was not built with files provider"
+
+    @pytest.mark.require.with_args(require_files_provider)
+    @pytest.mark.topology(KnownTopology.LDAP)
+    def test_example():
+        pass
+
 .. note::
 
     The requirement is evaluated when the test is executed but before setup

--- a/pytest_mh/__init__.py
+++ b/pytest_mh/__init__.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from ._private.artifacts import MultihostHostArtifacts, MultihostTopologyControllerArtifacts
 from ._private.data import MultihostItemData
 from ._private.fixtures import MultihostFixture, mh
 from ._private.marks import KnownTopologyBase, KnownTopologyGroupBase, TopologyMark
@@ -21,14 +22,18 @@ from ._private.topology_controller import TopologyController
 
 __all__ = [
     "mh",
+    "KnownTopologyBase",
+    "KnownTopologyGroupBase",
     "MultihostConfig",
     "MultihostDomain",
     "MultihostFixture",
     "MultihostHost",
+    "MultihostHostArtifacts",
     "MultihostHostOSFamily",
     "MultihostItemData",
     "MultihostPlugin",
     "MultihostRole",
+    "MultihostTopologyControllerArtifacts",
     "MultihostUtility",
     "pytest_addoption",
     "pytest_configure",
@@ -36,6 +41,4 @@ __all__ = [
     "TopologyController",
     "TopologyDomain",
     "TopologyMark",
-    "KnownTopologyBase",
-    "KnownTopologyGroupBase",
 ]

--- a/pytest_mh/__init__.py
+++ b/pytest_mh/__init__.py
@@ -12,7 +12,7 @@ from ._private.multihost import (
     MultihostConfig,
     MultihostDomain,
     MultihostHost,
-    MultihostHostOSFamily,
+    MultihostOSFamily,
     MultihostRole,
     MultihostUtility,
 )
@@ -29,8 +29,8 @@ __all__ = [
     "MultihostFixture",
     "MultihostHost",
     "MultihostHostArtifacts",
-    "MultihostHostOSFamily",
     "MultihostItemData",
+    "MultihostOSFamily",
     "MultihostPlugin",
     "MultihostRole",
     "MultihostTopologyControllerArtifacts",

--- a/pytest_mh/_private/artifacts.py
+++ b/pytest_mh/_private/artifacts.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import tarfile
+from base64 import b64decode
+from io import BytesIO
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias, get_args
+
+from ..ssh import SSHLog
+from .misc import sanitize_path, should_collect_artifacts
+from .types import MultihostOSFamily, MultihostOutcome
+
+if TYPE_CHECKING:
+    from .logging import MultihostLogger
+    from .multihost import MultihostHost
+
+
+MultihostArtifactsType: TypeAlias = Literal[
+    "pytest_setup", "pytest_teardown", "topology_setup", "topology_teardown", "test"
+]
+"""
+Multihost artifacts type.
+
+* ``pytest_setup``: collected after :meth:`MultihostHost.pytest_setup`
+* ``pytest_teardown``: collected after :meth:`MultihostHost.pytest_teardown`
+* ``topology_setup``: collected after :meth:`TopologyController.topology_setup`
+* ``topology_teardown``: collected after :meth:`TopologyController.topology_teardown`
+* ``test``: collected after each test run
+"""
+
+
+MultihostArtifactsMode: TypeAlias = Literal["never", "on-failure", "always"]
+"""
+Multihost artifacts mode.
+
+Defines if artifacts should be collected or not.
+"""
+
+
+class MultihostHostArtifacts(object):
+    """
+    Manage set of artifacts that are collected at specific places.
+    """
+
+    def __init__(self, config: list[str] | dict[str, list[str]] | None = None) -> None:
+        self.pytest_setup: set[str] = set()
+        """
+        List of artifacts collected for host after initial pytest_setup.
+
+        See :meth:`MultihostHost.pytest_setup`.
+        """
+
+        self.pytest_teardown: set[str] = set()
+        """
+        List of artifacts collected for host after final pytest_teardown.
+
+        See :meth:`MultihostHost.pytest_teardown`.
+        """
+
+        self.test: set[str] = set()
+        """
+        List of artifacts collected for a test when the test run is finished.
+        """
+
+        if config is not None:
+            if isinstance(config, list):
+                self.test = set(config)
+            elif isinstance(config, dict):
+                allowed = ["pytest_setup", "pytest_teardown", "test"]
+                for key in config.keys():
+                    if key not in allowed:
+                        raise ValueError(f"Invalid key: {key}, expected {allowed}")
+
+                self.pytest_setup = set(config.get("pytest_setup", set()))
+                self.pytest_teardown = set(config.get("pytest_teardown", set()))
+                self.test = set(config.get("test", set()))
+            else:
+                raise TypeError(f"Unsupported type: {type(config)}, expected list or dict")
+
+    def get(self, artifacts_type: MultihostArtifactsType) -> set[str]:
+        """
+        Get list of artifacts by type.
+
+        :param artifacts_type: Type to retrieve.
+        :type artifacts_type: MultihostArtifactsType
+        :raises ValueError: If invalid artifacts type is given.
+        :return: List of artifacts.
+        :rtype: set[str]
+        """
+        allowed = get_args(MultihostArtifactsType)
+        if artifacts_type not in allowed:
+            raise ValueError(f"Invalid artifacts type {artifacts_type}, expected {allowed}")
+
+        if not hasattr(self, artifacts_type):
+            return set()
+
+        return getattr(self, artifacts_type)
+
+
+class MultihostTopologyControllerArtifacts(object):
+    """
+    Manage set of artifacts that are collected at specific places.
+    """
+
+    def __init__(self) -> None:
+        self.topology_setup: dict[MultihostHost, set[str]] = {}
+        """
+        List of artifacts collected for host after initial topology_setup.
+
+        See :meth:`TopologyController.topology_setup`.
+        """
+
+        self.topology_teardown: dict[MultihostHost, set[str]] = {}
+        """
+        List of artifacts collected for host after final topology_teardown.
+
+        See :meth:`TopologyController.topology_teardown`.
+        """
+
+        self.test: dict[MultihostHost, set[str]] = {}
+        """
+        List of artifacts collected for host when a test run is finished.
+        """
+
+    def get(self, host: MultihostHost, artifacts_type: MultihostArtifactsType) -> set[str]:
+        """
+        Get list of artifacts by host and type.
+
+        :param artifacts_type: Type to retrieve.
+        :type artifacts_type: MultihostArtifactsType
+        :raises ValueError: If invalid artifacts type is given.
+        :return: List of artifacts.
+        :rtype: set[str]
+        """
+        allowed = get_args(MultihostArtifactsType)
+        if artifacts_type not in allowed:
+            raise ValueError(f"Invalid artifacts type {artifacts_type}, expected {allowed}")
+
+        if not hasattr(self, artifacts_type):
+            return set()
+
+        artifacts: dict[MultihostHost, set[str]] = getattr(self, artifacts_type)
+        return artifacts.get(host, set())
+
+
+class MultihostArtifactsCollectable(Protocol):
+    """
+    Protocol: object supports artifacts collection.
+    """
+
+    def get_artifacts_list(self, host: MultihostHost, type: MultihostArtifactsType) -> set[str]:
+        """
+        Return the list of artifacts to collect.
+
+        This just returns :attr:`artifacts`, but it is possible to override this
+        method in order to generate additional artifacts that were not created
+        by the test, or detect which artifacts were created and update the
+        artifacts list.
+
+        :param host: Host where the artifacts are being collected.
+        :type host: MultihostHost
+        :param type: Type of artifacts that are being collected.
+        :type type: MultihostArtifactsType
+        :return: List of artifacts to collect.
+        :rtype: set[str]
+        """
+        pass
+
+
+class MultihostArtifactsCollector(object):
+    """
+    Multihost artifacts collector.
+    """
+
+    def __init__(
+        self,
+        *,
+        host: MultihostHost,
+        path: Path | str,
+        mode: MultihostArtifactsMode,
+        compress: bool,
+    ) -> None:
+        """
+        :param host: MultihostHost object.
+        :type host: MultihostHost
+        :param path: Artifacts directory path.
+        :type path: Path | str
+        :param mode: Artifacts collection mode.
+        :type mode: MultihostArtifactsMode
+        :param compress: Store artifacts in compressed tarball or not?
+        :type compress: bool
+        """
+        self.path: Path = Path(path)
+        self.host: MultihostHost = host
+        self.logger: MultihostLogger = host.logger
+        self.mode: MultihostArtifactsMode = mode
+        self.compress: bool = compress
+
+    def should_collect(self, outcome: MultihostOutcome) -> bool:
+        """
+        Match mode and outcome in order to decide if artifacts should be
+        collected/written or not.
+
+        :param outcome: Test or operation outcome.
+        :type outcome: MultihostOutcome
+        :raises ValueError: If mode is not recognized.
+        :return: True if artifacts should be collected, False otherwise.
+        :rtype: bool
+        """
+        return should_collect_artifacts(self.mode, outcome)
+
+    def collect(
+        self,
+        type: MultihostArtifactsType,
+        *,
+        path: str,
+        outcome: MultihostOutcome,
+        collect_objects: list[MultihostArtifactsCollectable],
+    ) -> None:
+        """
+        Collect artifacts to $artifacts_dir/$path/$collection_path.
+
+        :param type: Artifacts type.
+        :type type: MultihostArtifactsType
+        :param path: Artifacts path relative to artifacts directory.
+        :type path: str
+        :param outcome: Test or operation outcome.
+        :type outcome: MultihostOutcome
+        :param collect_objects: Objects from which artifacts will be collected.
+        :type collect_objects: list[MultihostArtifactCollectionType]
+        :raises Exception: If error happens when obtaining artifacts list.
+        :raises NotImplementedError: If an attempt to collect artifacts on Windows host is performed.
+        :raises ValueError: If host with unknown operating system is given.
+        """
+        if not self.should_collect(outcome):
+            self.logger.info("Artifacts are not collected")
+            return
+
+        # Substitute problematic characters and create destination path
+        dest = self.path / sanitize_path(path)
+
+        # Gather list of artifacts to collect
+        errors = []
+        artifacts_set: set[str] = set()
+        for obj in collect_objects:
+            try:
+                artifacts_set.update(obj.get_artifacts_list(self.host, type))
+            except Exception as e:
+                errors.append(e)
+
+        if errors:
+            raise Exception(errors)
+
+        # Sort artifacts by name
+        artifacts = sorted(artifacts_set)
+        if not artifacts:
+            self.logger.info("No artifacts to collect.")
+            return
+
+        self.logger.info(
+            "Collecting artifacts",
+            extra={
+                "data": {
+                    "Local destination": dest if not self.compress else f"{dest}.tgz",
+                    "Artifacts": artifacts,
+                }
+            },
+        )
+
+        # Create output directory, skip the last part since it is the
+        # tarball/collection name.
+        dest.parent.mkdir(parents=True, exist_ok=True)
+
+        # Collect artifacts
+        match self.host.os_family:
+            case MultihostOSFamily.Linux:
+                command = f"""
+                    tmp=`mktemp /tmp/mh.host.artifacts.XXXXXXXXX`
+                    tar -hczvf "$tmp" {' '.join([f'$(compgen -G "{x}")' for x in artifacts])} &> /dev/null
+                    base64 "$tmp"
+                    rm -f "$tmp" &> /dev/null
+                """
+            case MultihostOSFamily.Windows:
+                raise NotImplementedError("Artifacts are not supported on Windows machine")
+            case _:
+                raise ValueError(f"Unknown operating system: {self.host.os_family}")
+
+        result = self.host.ssh.run(command, log_level=SSHLog.Error)
+
+        # Return if no artifacts were obtained
+        if not result.stdout:
+            return
+
+        with BytesIO(b64decode(result.stdout)) as buffer:
+            if self.compress:
+                # Store artifacts in single archive
+                with open(f"{dest}.tgz", "wb") as f:
+                    f.write(buffer.getbuffer())
+            else:
+                # Extract archive for convenience
+                with tarfile.open(fileobj=buffer) as tar:
+                    tar.extractall(str(dest))

--- a/pytest_mh/_private/data.py
+++ b/pytest_mh/_private/data.py
@@ -4,6 +4,7 @@ import pytest
 
 from .marks import TopologyMark
 from .multihost import MultihostConfig
+from .types import MultihostOutcome
 
 
 class MultihostItemData(object):
@@ -22,7 +23,7 @@ class MultihostItemData(object):
         Topology mark for the test run.
         """
 
-        self.outcome: str | None = None
+        self.outcome: MultihostOutcome = "unknown"
         """
         Test run outcome, available in fixture finalizers.
         """

--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable, Generator
 
@@ -9,7 +10,7 @@ import pytest
 from .data import MultihostItemData
 from .logging import MultihostLogger
 from .marks import TopologyMark
-from .misc import invoke_callback, sanitize_path
+from .misc import invoke_callback
 from .multihost import (
     MultihostArtifactCollectionType,
     MultihostConfig,
@@ -294,22 +295,7 @@ class MultihostFixture(object):
         Write log messages produced by current test case to a file, or clear
         them if no artifacts should be generated.
         """
-        write_log = False
-        match self.multihost.artifacts_mode:
-            case "never":
-                write_log = False
-            case "always":
-                write_log = True
-            case "on-failure":
-                write_log = self.data.outcome in ("failed", "error", "unknown")
-            case _:
-                raise ValueError(f"Unexpected artifacts collection mode: {self.multihost.artifacts_mode}")
-
-        if not write_log:
-            self.logger.clear()
-        else:
-            name = sanitize_path(self.request.node.name)
-            self.logger.write_to_file(f"{self.multihost.artifacts_dir}/{name}/test.log")
+        self.logger.flush(Path(self.request.node.name) / "test.log", self.data.outcome)
 
     def _invoke_phase(self, name: str, cb: Callable, catch: bool = False) -> Exception | None:
         self.log_phase(name)

--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -346,8 +346,13 @@ class MultihostFixture(object):
             return self
 
         self.log_phase("BEGIN")
-        self._invoke_phase("SETUP TOPOLOGY", self._topology_setup)
-        self._invoke_phase("SETUP TEST", self._setup)
+
+        try:
+            self._invoke_phase("SETUP TOPOLOGY", self._topology_setup)
+            self._invoke_phase("SETUP TEST", self._setup)
+        except Exception:
+            self.data.outcome = "error"
+            raise
 
         return self
 

--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable, Generator
 
-import colorama
 import pytest
 
 from .data import MultihostItemData
@@ -317,14 +316,7 @@ class MultihostFixture(object):
         :param phase: Phase name or description.
         :type phase: str
         """
-        self.logger.info(
-            self.logger.colorize(
-                f"{phase} :: {self.request.node.nodeid}",
-                colorama.Style.BRIGHT,
-                colorama.Back.BLACK,
-                colorama.Fore.WHITE,
-            )
-        )
+        self.logger.phase(f"{phase} :: {self.request.node.nodeid}")
 
     def _enter(self) -> MultihostFixture:
         if self._skip():

--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -258,8 +258,8 @@ class MultihostFixture(object):
             try:
                 host.artifacts_collector.collect(
                     "test",
-                    path=f"{self.request.node.name}",
-                    collection_path=f"{host.role}_{host.hostname}",
+                    path=f"tests/{self.request.node.name}",
+                    collection_path=f"{host.role}/{host.hostname}",
                     outcome=self.data.outcome,
                     collect_objects=collectable[host],
                 )
@@ -295,7 +295,7 @@ class MultihostFixture(object):
         Write log messages produced by current test case to a file, or clear
         them if no artifacts should be generated.
         """
-        self.logger.flush(Path(self.request.node.name) / "test.log", self.data.outcome)
+        self.logger.flush(Path(f"tests/{self.request.node.name}") / "test.log", self.data.outcome)
 
     def _invoke_phase(self, name: str, cb: Callable, catch: bool = False) -> Exception | None:
         self.log_phase(name)

--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -258,8 +258,7 @@ class MultihostFixture(object):
             try:
                 host.artifacts_collector.collect(
                     "test",
-                    path=f"tests/{self.request.node.name}",
-                    collection_path=f"{host.role}/{host.hostname}",
+                    path=f"tests/{self.request.node.name}/{host.role}/{host.hostname}",
                     outcome=self.data.outcome,
                     collect_objects=collectable[host],
                 )

--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -6,18 +6,12 @@ from typing import Any, Callable, Generator
 
 import pytest
 
+from .artifacts import MultihostArtifactsCollectable
 from .data import MultihostItemData
 from .logging import MultihostLogger
 from .marks import TopologyMark
 from .misc import invoke_callback
-from .multihost import (
-    MultihostArtifactCollectionType,
-    MultihostConfig,
-    MultihostDomain,
-    MultihostHost,
-    MultihostRole,
-    MultihostUtility,
-)
+from .multihost import MultihostConfig, MultihostDomain, MultihostHost, MultihostRole, MultihostUtility
 from .topology import Topology, TopologyDomain
 from .topology_controller import TopologyController
 
@@ -246,9 +240,9 @@ class MultihostFixture(object):
 
     def _collect_artifacts(self) -> None:
         # Create list of collectable objects
-        collectable: dict[MultihostHost, list[MultihostArtifactCollectionType]] = {}
+        collectable: dict[MultihostHost, list[MultihostArtifactsCollectable]] = {}
         for role in self.roles:
-            host_collection = collectable.setdefault(role.host, [role.host, role])
+            host_collection = collectable.setdefault(role.host, [role.host, self.topology_controller, role])
             host_collection.extend(MultihostUtility.GetUtilityAttributes(role).values())
 
         # Collect artifacts, if an error is raised, we will ignore it since

--- a/pytest_mh/_private/logging.py
+++ b/pytest_mh/_private/logging.py
@@ -4,12 +4,15 @@ import logging
 import textwrap
 from logging.handlers import MemoryHandler
 from pathlib import Path
-from typing import Any, Type
+from typing import TYPE_CHECKING, Any, Type
 
 import colorama
 
 from .misc import merge_dict, sanitize_path, should_collect_artifacts
-from .types import MultihostArtifactsMode, MultihostOutcome
+from .types import MultihostOutcome
+
+if TYPE_CHECKING:
+    from .artifacts import MultihostArtifactsMode
 
 
 class MultihostLogger(logging.Logger):

--- a/pytest_mh/_private/logging.py
+++ b/pytest_mh/_private/logging.py
@@ -136,6 +136,22 @@ class MultihostLogger(logging.Logger):
 
         return "".join(colors) + str(text) + colorama.Style.RESET_ALL
 
+    def phase(self, phase: str) -> None:
+        """
+        Log current phase.
+
+        :param phase: Phase name or description.
+        :type phase: str
+        """
+        self.info(
+            self.colorize(
+                f"{phase}",
+                colorama.Style.BRIGHT,
+                colorama.Back.BLACK,
+                colorama.Fore.WHITE,
+            )
+        )
+
     def debug(self, msg, *args, **kwargs):
         super().debug(msg, *args, **self._msgdata(kwargs))
 

--- a/pytest_mh/_private/misc.py
+++ b/pytest_mh/_private/misc.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 from functools import partial
 from inspect import getfullargspec
+from pathlib import Path
 from typing import Any, Callable
 
 
@@ -68,6 +69,19 @@ def invoke_callback(cb: Callable, /, **kwargs: Any) -> Any:
         callspec = kwargs
 
     return cb(**callspec)
+
+
+def sanitize_path(path: str | Path) -> Path:
+    """
+    Replace problematic characters in file path.
+
+    :param path: Path to sanitize.
+    :type path: str | Path
+    :return: Sanitized path.
+    :rtype: Path
+    """
+    table = str.maketrans('":<>|*? [', "---------", "]()")
+    return Path(str(path).translate(table))
 
 
 class OperationStatus(object):

--- a/pytest_mh/_private/misc.py
+++ b/pytest_mh/_private/misc.py
@@ -4,9 +4,12 @@ from copy import deepcopy
 from functools import partial
 from inspect import getfullargspec
 from pathlib import Path
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
-from .types import MultihostArtifactsMode, MultihostOutcome
+from .types import MultihostOutcome
+
+if TYPE_CHECKING:
+    from .artifacts import MultihostArtifactsMode
 
 
 def merge_dict(*args: dict | None):

--- a/pytest_mh/_private/misc.py
+++ b/pytest_mh/_private/misc.py
@@ -6,6 +6,8 @@ from inspect import getfullargspec
 from pathlib import Path
 from typing import Any, Callable
 
+from .types import MultihostArtifactsMode, MultihostOutcome
+
 
 def merge_dict(*args: dict | None):
     """
@@ -82,6 +84,30 @@ def sanitize_path(path: str | Path) -> Path:
     """
     table = str.maketrans('":<>|*? [', "---------", "]()")
     return Path(str(path).translate(table))
+
+
+def should_collect_artifacts(mode: MultihostArtifactsMode, outcome: MultihostOutcome) -> bool:
+    """
+    Match mode and outcome in order to decide if artifacts should be
+    collected/written or not.
+
+    :param mode: Artifacts collect mode.
+    :type mode: MultihostArtifactsMode
+    :param outcome: Test or operation outcome.
+    :type outcome: MultihostOutcome
+    :raises ValueError: If mode is not recognized.
+    :return: True if artifacts should be collected, False otherwise.
+    :rtype: bool
+    """
+    match mode:
+        case "never":
+            return False
+        case "always":
+            return True
+        case "on-failure":
+            return outcome in ("failed", "error", "unknown")
+
+    raise ValueError(f"Unexpected artifacts collection mode: {mode}")
 
 
 class OperationStatus(object):

--- a/pytest_mh/_private/misc.py
+++ b/pytest_mh/_private/misc.py
@@ -3,13 +3,7 @@ from __future__ import annotations
 from copy import deepcopy
 from functools import partial
 from inspect import getfullargspec
-from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Callable
-
-from .topology import Topology, TopologyDomain
-
-if TYPE_CHECKING:
-    from .multihost import MultihostConfig, MultihostDomain, MultihostHost
+from typing import Any, Callable
 
 
 def merge_dict(*args: dict | None):
@@ -74,93 +68,6 @@ def invoke_callback(cb: Callable, /, **kwargs: Any) -> Any:
         callspec = kwargs
 
     return cb(**callspec)
-
-
-def topology_domain_to_host_namespace(
-    topology_domain: TopologyDomain, mh_domain: MultihostDomain
-) -> tuple[SimpleNamespace, dict[str, MultihostHost | list[MultihostHost]]]:
-    """
-    Convert topology domain into a namespace of MultihostHost objects accessible
-    by roles names.
-
-    :param topology_domain: Topology domain.
-    :type topology_domain: TopologyDomain
-    :param mh_domain: MultihostDomain
-    :type mh_domain: MultihostDomain
-    :return: Pair of namespace and path to host mapping.
-    :rtype: tuple[SimpleNamespace, dict[str, MultihostHost | list[MultihostHost]]]
-    """
-    ns = SimpleNamespace()
-    paths: dict[str, MultihostHost | list[MultihostHost]] = {}
-
-    for role_name in mh_domain.roles:
-        if role_name not in topology_domain:
-            continue
-
-        count = topology_domain.get(role_name)
-        hosts = [host for host in mh_domain.hosts_by_role(role_name)[:count]]
-        setattr(ns, role_name, hosts)
-
-        paths[f"{topology_domain.id}.{role_name}"] = hosts
-        for index, host in enumerate(hosts):
-            paths[f"{topology_domain.id}.{role_name}[{index}]"] = host
-
-    return (ns, paths)
-
-
-def topology_to_host_namespace(
-    topology: Topology, mh_domains: list[MultihostDomain]
-) -> tuple[SimpleNamespace, dict[str, MultihostHost | list[MultihostHost]]]:
-    """
-    Convert topology into a namespace of MultihostHost objects accessible
-    by domain id and roles names.
-
-    :param topology: Topology.
-    :type topology: Topology
-    :param mh_domains: List of MultihostDomain
-    :type mh_domains: list[MultihostDomain]
-    :return: Pair of namespace and path to host mapping.
-    :rtype: tuple[SimpleNamespace, dict[str, MultihostHost | list[MultihostHost]]]
-    """
-    root = SimpleNamespace()
-    paths: dict[str, MultihostHost | list[MultihostHost]] = {}
-
-    for mh_domain in mh_domains:
-        if mh_domain.id in topology:
-            ns, nspaths = topology_domain_to_host_namespace(topology.get(mh_domain.id), mh_domain)
-            setattr(root, mh_domain.id, ns)
-            paths.update(**nspaths)
-
-    return root, paths
-
-
-def topology_controller_parameters(
-    mh_config: MultihostConfig, topology: Topology, fixtures: dict[str, str]
-) -> dict[str, Any]:
-    """
-    Create dictionary of parameters for topology controller hooks.
-
-    :param mh_config: MultihostConfig object.
-    :type mh_config: MultihostConfig
-    :param topology: Topology.
-    :type topology: Topology
-    :param fixtures: Topology fixtures.
-    :type fixtures: dict[str, str]
-    :return: Parameters.
-    :rtype: dict[str, Any]
-    """
-    ns, paths = topology_to_host_namespace(topology, mh_config.domains)
-
-    args = {}
-    for name, path in fixtures.items():
-        args[name] = paths[path]
-
-    return {
-        "mhc": mh_config,
-        "logger": mh_config.logger,
-        "ns": ns,
-        **args,
-    }
 
 
 class OperationStatus(object):

--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -18,7 +18,7 @@ from .logging import MultihostHostLogger, MultihostLogger
 from .marks import TopologyMark
 from .misc import OperationStatus
 from .topology import Topology
-from .types import MultihostHostOSFamily
+from .types import MultihostOSFamily
 from .utils import validate_configuration
 
 if TYPE_CHECKING:
@@ -359,18 +359,18 @@ class MultihostHost(Generic[DomainType]):
         # Get host operating system information
         os = confdict.get("os", {})
 
-        os_family = str(os.get("family", MultihostHostOSFamily.Linux.value)).lower()
+        os_family = str(os.get("family", MultihostOSFamily.Linux.value)).lower()
         try:
-            self.os_family: MultihostHostOSFamily = MultihostHostOSFamily(os_family)
+            self.os_family: MultihostOSFamily = MultihostOSFamily(os_family)
             """Host operating system os_family."""
         except ValueError:
             raise ValueError(f'Value "{os_family}" is not supported in os_family field of host configuration')
 
         # Set host shell based on the operating system
         match self.os_family:
-            case MultihostHostOSFamily.Linux:
+            case MultihostOSFamily.Linux:
                 self.shell = SSHBashProcess
-            case MultihostHostOSFamily.Windows:
+            case MultihostOSFamily.Windows:
                 self.shell = SSHPowerShellProcess
             case _:
                 raise ValueError(f"Unknown operating system os_family: {self.os_family}")

--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -8,7 +8,7 @@ from enum import Enum
 from functools import wraps
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generic, Protocol, Type, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Type, TypeVar
 
 from ..cli import CLIBuilder
 from ..ssh import SSHBashProcess, SSHClient, SSHLog, SSHPowerShellProcess, SSHProcess
@@ -16,7 +16,7 @@ from .logging import MultihostHostLogger, MultihostLogger
 from .marks import TopologyMark
 from .misc import OperationStatus, sanitize_path, should_collect_artifacts
 from .topology import Topology
-from .types import MultihostArtifactsMode, MultihostArtifactsType, MultihostOutcome
+from .types import MultihostArtifactCollectionType, MultihostArtifactsMode, MultihostArtifactsType, MultihostOutcome
 from .utils import validate_configuration
 
 if TYPE_CHECKING:
@@ -718,28 +718,6 @@ class MultihostUtility(Generic[HostType]):
         """
         method.__mh_ignore_call = True
         return method
-
-
-class MultihostArtifactCollectionType(Protocol):
-    """
-    Hints that given object supports artifacts collection.
-    """
-
-    def get_artifacts_list(self, type: MultihostArtifactsType) -> set[str]:
-        """
-        Return the list of artifacts to collect.
-
-        This just returns :attr:`artifacts`, but it is possible to override this
-        method in order to generate additional artifacts that were not created
-        by the test, or detect which artifacts were created and update the
-        artifacts list.
-
-        :param type: Type of artifacts that are being collected.
-        :type type: MultihostArtifactsType
-        :return: List of artifacts to collect.
-        :rtype: set[str]
-        """
-        pass
 
 
 class MultihostArtifactsCollector(object):

--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -144,8 +144,8 @@ class MultihostPlugin(object):
                     host.pytest_teardown()
                 except Exception as e:
                     errors.append(e)
-
-        self.multihost.logger.write_to_file(f"{self.mh_artifacts_dir}/teardown.log")
+                finally:
+                    self.multihost.logger.write_to_file(f"{self.mh_artifacts_dir}/teardown_host_{host.hostname}.log")
 
         if errors:
             raise Exception(errors)
@@ -269,12 +269,12 @@ class MultihostPlugin(object):
         mark: TopologyMark = data.topology_mark
 
         # Run pytest_setup on all hosts required by selected tests
-        try:
-            for host in self.required_hosts:
+        for host in self.required_hosts:
+            try:
                 host.pytest_setup()
                 host._op_state.set_success("pytest_setup")
-        finally:
-            self.multihost.logger.write_to_file(f"{self.mh_artifacts_dir}/setup.log")
+            finally:
+                self.multihost.logger.write_to_file(f"{self.mh_artifacts_dir}/setup_host_{host.hostname}.log")
 
         # Execute per-topology setup if topology is switched.
         if self._topology_switch(None, item):

--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -483,9 +483,11 @@ class MultihostPlugin(object):
 
         for host in hosts:
             try:
+                host.logger.phase(f"PYTEST SETUP :: {host.hostname}")
                 host.pytest_setup()
                 host._op_state.set_success("pytest_setup")
             finally:
+                host.logger.phase(f"PYTEST SETUP DONE :: {host.hostname}")
                 outcome: MultihostOutcome = "error"
                 if host._op_state.check_success("pytest_setup"):
                     outcome = "passed"
@@ -501,11 +503,13 @@ class MultihostPlugin(object):
         for host in hosts:
             if host._op_state.check_success("pytest_setup"):
                 try:
+                    host.logger.phase(f"PYTEST TEARDOWN :: {host.hostname}")
                     host.pytest_teardown()
                     host._op_state.set_success("pytest_teardown")
                 except Exception as e:
                     errors.append(e)
                 finally:
+                    host.logger.phase(f"PYTEST TEARDOWN DONE :: {host.hostname}")
                     outcome: MultihostOutcome = "error"
                     if host._op_state.check_success("pytest_teardown"):
                         outcome = "passed"
@@ -521,9 +525,11 @@ class MultihostPlugin(object):
             raise RuntimeError("Multihost configuration is not present.")
 
         try:
+            controller.logger.phase(f"TOPOLOGY SETUP :: {controller.name}")
             controller._invoke_with_args(controller.topology_setup)
             controller._op_state.set_success("topology_setup")
         finally:
+            controller.logger.phase(f"TOPOLOGY SETUP DONE :: {controller.name}")
             outcome: MultihostOutcome = "error"
             if controller._op_state.check_success("topology_setup"):
                 outcome = "passed"
@@ -537,10 +543,12 @@ class MultihostPlugin(object):
 
         try:
             if controller._op_state.check_success("topology_setup"):
+                controller.logger.phase(f"TOPOLOGY TEARDOWN :: {controller.name}")
                 controller._invoke_with_args(controller.topology_teardown)
                 controller._op_state.set_success("topology_teardown")
         finally:
             self.current_topology = None
+            controller.logger.phase(f"TOPOLOGY TEARDOWN DONE :: {controller.name}")
             outcome: MultihostOutcome = "error"
             if controller._op_state.check_success("topology_teardown"):
                 outcome = "passed"

--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -10,6 +10,7 @@ from typing import Generator, Type
 import pytest
 import yaml
 
+from .artifacts import MultihostArtifactsCollectable, MultihostArtifactsType
 from .data import MultihostItemData
 from .fixtures import MultihostFixture
 from .logging import MultihostLogger
@@ -17,7 +18,7 @@ from .marks import TopologyMark
 from .multihost import MultihostArtifactsMode, MultihostConfig, MultihostHost
 from .topology import Topology
 from .topology_controller import TopologyController
-from .types import MultihostArtifactCollectionType, MultihostArtifactsType, MultihostOutcome
+from .types import MultihostOutcome
 
 MarkStashKey = pytest.StashKey[TopologyMark | None]()
 
@@ -603,7 +604,7 @@ class MultihostPlugin(object):
         hostdir: bool,
         type: MultihostArtifactsType,
         path: str,
-        collectable: dict[MultihostHost, list[MultihostArtifactCollectionType]],
+        collectable: dict[MultihostHost, list[MultihostArtifactsCollectable]],
         outcome: MultihostOutcome,
         logger: MultihostLogger,
     ) -> None:

--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -546,6 +546,7 @@ class MultihostPlugin(object):
 
         try:
             controller.logger.phase(f"TOPOLOGY SETUP :: {name}")
+            controller._invoke_with_args(controller.set_artifacts)
             controller._invoke_with_args(controller.topology_setup)
             controller._op_state.set_success("topology_setup")
         finally:
@@ -559,7 +560,7 @@ class MultihostPlugin(object):
                 hostdir=True,
                 type="topology_setup",
                 path=f"topologies/{name}/topology_setup",
-                collectable={x: [x] for x in controller.hosts},
+                collectable={x: [x, controller] for x in controller.hosts},
                 outcome=outcome,
                 logger=controller.logger,
             )
@@ -588,7 +589,7 @@ class MultihostPlugin(object):
                 hostdir=True,
                 type="topology_teardown",
                 path=f"topologies/{name}/topology_teardown",
-                collectable={x: [x] for x in controller.hosts},
+                collectable={x: [x, controller] for x in controller.hosts},
                 outcome=outcome,
                 logger=controller.logger,
             )

--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -159,7 +159,7 @@ class MultihostPlugin(object):
                 except Exception as e:
                     errors.append(e)
                 finally:
-                    self.multihost.logger.flush(f"hosts/{host.hostname}/teardown.log", "unknown")
+                    self.multihost.logger.flush(f"hosts/{host.hostname}/pytest_teardown.log", "unknown")
 
         if errors:
             raise Exception(errors)
@@ -288,7 +288,7 @@ class MultihostPlugin(object):
                 host.pytest_setup()
                 host._op_state.set_success("pytest_setup")
             finally:
-                self.multihost.logger.flush(f"hosts/{host.hostname}/setup.log", "unknown")
+                self.multihost.logger.flush(f"hosts/{host.hostname}/pytest_setup.log", "unknown")
 
         # Execute per-topology setup if topology is switched.
         if self._topology_switch(None, item):
@@ -297,7 +297,7 @@ class MultihostPlugin(object):
                 mark.controller._op_state.set_success("topology_setup")
             finally:
                 self.current_topology = mark.name
-                self.multihost.logger.flush(f"topologies/{mark.name}/setup.log", "unknown")
+                self.multihost.logger.flush(f"topologies/{mark.name}/topology_setup.log", "unknown")
 
         # Make mh fixture always available
         if "mh" not in item.fixturenames:
@@ -353,7 +353,7 @@ class MultihostPlugin(object):
                     mark.controller._invoke_with_args(mark.controller.topology_teardown)
             finally:
                 self.current_topology = None
-                self.multihost.logger.flush(f"topologies/{mark.name}/teardown.log", "unknown")
+                self.multihost.logger.flush(f"topologies/{mark.name}/topology_teardown.log", "unknown")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_makereport(

--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -280,6 +280,7 @@ class MultihostPlugin(object):
         if self._topology_switch(None, item):
             try:
                 mark.controller._invoke_with_args(mark.controller.topology_setup)
+                mark.controller._op_state.set_success("topology_setup")
             finally:
                 self.current_topology = mark.name
                 self.multihost.logger.write_to_file(f"{self.mh_artifacts_dir}/setup_topology_{mark.name}.log")
@@ -329,7 +330,8 @@ class MultihostPlugin(object):
         # Execute per-topology teardown if topology changed.
         if self._topology_switch(item, nextitem):
             try:
-                mark.controller._invoke_with_args(mark.controller.topology_teardown)
+                if mark.controller._op_state.check_success("topology_setup"):
+                    mark.controller._invoke_with_args(mark.controller.topology_teardown)
             finally:
                 self.current_topology = None
                 self.multihost.logger.write_to_file(f"{self.mh_artifacts_dir}/teardown_topology_{mark.name}.log")

--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -159,7 +159,7 @@ class MultihostPlugin(object):
                 except Exception as e:
                     errors.append(e)
                 finally:
-                    self.multihost.logger.flush(f"teardown_host_{host.hostname}.log", "unknown")
+                    self.multihost.logger.flush(f"hosts/{host.hostname}/teardown.log", "unknown")
 
         if errors:
             raise Exception(errors)
@@ -288,7 +288,7 @@ class MultihostPlugin(object):
                 host.pytest_setup()
                 host._op_state.set_success("pytest_setup")
             finally:
-                self.multihost.logger.flush(f"setup_host_{host.hostname}.log", "unknown")
+                self.multihost.logger.flush(f"hosts/{host.hostname}/setup.log", "unknown")
 
         # Execute per-topology setup if topology is switched.
         if self._topology_switch(None, item):
@@ -297,7 +297,7 @@ class MultihostPlugin(object):
                 mark.controller._op_state.set_success("topology_setup")
             finally:
                 self.current_topology = mark.name
-                self.multihost.logger.flush(f"setup_topology_{mark.name}.log", "unknown")
+                self.multihost.logger.flush(f"topologies/{mark.name}/setup.log", "unknown")
 
         # Make mh fixture always available
         if "mh" not in item.fixturenames:
@@ -353,7 +353,7 @@ class MultihostPlugin(object):
                     mark.controller._invoke_with_args(mark.controller.topology_teardown)
             finally:
                 self.current_topology = None
-                self.multihost.logger.flush(f"teardown_topology_{mark.name}.log", "unknown")
+                self.multihost.logger.flush(f"topologies/{mark.name}/teardown.log", "unknown")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_makereport(

--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -46,6 +46,11 @@ class MultihostPlugin(object):
         self.mh_artifacts_dir: Path = Path(pytest_config.getoption("mh_artifacts_dir"))
         self.mh_compress_artifacts: bool = pytest_config.getoption("mh_compress_artifacts")
 
+        # Read --mh-collect-logs, default to --mh-collect-artifacts
+        self.mh_collect_logs: MultihostArtifactsMode = pytest_config.getoption("mh_collect_logs")
+        if self.mh_collect_logs is None:
+            self.mh_collect_logs = self.mh_collect_artifacts
+
     @classmethod
     def GetLogger(cls) -> logging.Logger:
         """
@@ -90,7 +95,7 @@ class MultihostPlugin(object):
         logger = MultihostLogger.GetLogger()
         logger.setup(
             log_path=self.mh_log_path,
-            artifacts_mode=self.mh_collect_artifacts,
+            artifacts_mode=self.mh_collect_logs,
             artifacts_dir=self.mh_artifacts_dir,
             confdict=self.confdict,
         )
@@ -140,6 +145,7 @@ class MultihostPlugin(object):
         self.logger.info(f"  require exact topology: {self.mh_exact_topology}")
         self.logger.info(f"  collect artifacts: {self.mh_collect_artifacts}")
         self.logger.info(f"  artifacts directory: {self.mh_artifacts_dir}")
+        self.logger.info(f"  collect logs: {self.mh_collect_logs}")
         self.logger.info("")
 
     @pytest.hookimpl(trylast=True)
@@ -564,6 +570,15 @@ def pytest_addoption(parser):
         "--mh-compress-artifacts",
         action="store_true",
         help="If set, test artifacts are stored in a compressed archive",
+    )
+
+    parser.addoption(
+        "--mh-collect-logs",
+        action="store",
+        default=None,
+        nargs="?",
+        choices=["never", "on-failure", "always"],
+        help="Collect logs mode (default: use value of --mh-collect-artifacts)",
     )
 
 

--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -319,6 +319,11 @@ class MultihostPlugin(object):
 
     @pytest.hookimpl(trylast=True)
     def pytest_runtest_teardown(self, item: pytest.Item, nextitem: pytest.Item | None) -> None:
+        """
+        Teardown topology if we detect a topology switch.
+
+        :meta private:
+        """
         if self.multihost is None:
             return
 

--- a/pytest_mh/_private/topology_controller.py
+++ b/pytest_mh/_private/topology_controller.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable
 from .logging import MultihostLogger
 from .misc import OperationStatus, invoke_callback
 from .topology import Topology, TopologyDomain
+from .types import MultihostArtifactsType
 
 if TYPE_CHECKING:
     from .multihost import MultihostConfig, MultihostDomain, MultihostHost
@@ -108,6 +109,13 @@ class TopologyController(object):
         self.__ns: SimpleNamespace | None = None
         self.__args: dict[str, MultihostHost | list[MultihostHost]] | None = None
         self.__initialized: bool = False
+
+        self.artifacts: set[str] = set()
+        """
+        List of artifacts that will be automatically collected when a test is
+        finished. This list can be dynamically extended. Values may contain
+        wildcard character.
+        """
 
     def _init(
         self,
@@ -272,6 +280,31 @@ class TopologyController(object):
             raise RuntimeError("TopologyController has not been initialized yet")
 
         return self.__hosts
+
+    def get_artifacts_list(self, type: MultihostArtifactsType) -> set[str]:
+        """
+        Return the list of artifacts to collect.
+
+        This just returns :attr:`artifacts`, but it is possible to override this
+        method in order to generate additional artifacts that were not created
+        by the test, or detect which artifacts were created and update the
+        artifacts list.
+
+        :param type: Type of artifacts that are being collected.
+        :type type: MultihostArtifactsType
+        :return: List of artifacts to collect.
+        :rtype: set[str]
+        """
+        return self.artifacts
+
+    def set_artifacts(self) -> None:
+        """
+        Called before :meth:`topology_setup` to set topology artifacts.
+
+        Note that the artifacts can be set in any other method as well. This
+        dedicated method is just for your convenience.
+        """
+        return
 
     def skip(self) -> str | None:
         """

--- a/pytest_mh/_private/types.py
+++ b/pytest_mh/_private/types.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from typing import Literal, TypeAlias
+
+MultihostArtifactsType: TypeAlias = Literal["test"]
+MultihostArtifactsMode: TypeAlias = Literal["never", "on-failure", "always"]
+MultihostOutcome: TypeAlias = Literal["passed", "failed", "skipped", "error", "unknown"]

--- a/pytest_mh/_private/types.py
+++ b/pytest_mh/_private/types.py
@@ -1,31 +1,16 @@
 from __future__ import annotations
 
-from typing import Literal, Protocol, TypeAlias
+from enum import Enum
+from typing import Literal, TypeAlias
 
-MultihostArtifactsType: TypeAlias = Literal[
-    "test", "pytest_setup", "pytest_teardown", "topology_setup", "topology_teardown"
-]
-MultihostArtifactsMode: TypeAlias = Literal["never", "on-failure", "always"]
+
+class MultihostHostOSFamily(Enum):
+    """
+    Host operating system family.
+    """
+
+    Linux = "linux"
+    Windows = "windows"
+
+
 MultihostOutcome: TypeAlias = Literal["passed", "failed", "skipped", "error", "unknown"]
-
-
-class MultihostArtifactCollectionType(Protocol):
-    """
-    Hints that given object supports artifacts collection.
-    """
-
-    def get_artifacts_list(self, type: MultihostArtifactsType) -> set[str]:
-        """
-        Return the list of artifacts to collect.
-
-        This just returns :attr:`artifacts`, but it is possible to override this
-        method in order to generate additional artifacts that were not created
-        by the test, or detect which artifacts were created and update the
-        artifacts list.
-
-        :param type: Type of artifacts that are being collected.
-        :type type: MultihostArtifactsType
-        :return: List of artifacts to collect.
-        :rtype: set[str]
-        """
-        pass

--- a/pytest_mh/_private/types.py
+++ b/pytest_mh/_private/types.py
@@ -1,7 +1,31 @@
 from __future__ import annotations
 
-from typing import Literal, TypeAlias
+from typing import Literal, Protocol, TypeAlias
 
-MultihostArtifactsType: TypeAlias = Literal["test"]
+MultihostArtifactsType: TypeAlias = Literal[
+    "test", "pytest_setup", "pytest_teardown", "topology_setup", "topology_teardown"
+]
 MultihostArtifactsMode: TypeAlias = Literal["never", "on-failure", "always"]
 MultihostOutcome: TypeAlias = Literal["passed", "failed", "skipped", "error", "unknown"]
+
+
+class MultihostArtifactCollectionType(Protocol):
+    """
+    Hints that given object supports artifacts collection.
+    """
+
+    def get_artifacts_list(self, type: MultihostArtifactsType) -> set[str]:
+        """
+        Return the list of artifacts to collect.
+
+        This just returns :attr:`artifacts`, but it is possible to override this
+        method in order to generate additional artifacts that were not created
+        by the test, or detect which artifacts were created and update the
+        artifacts list.
+
+        :param type: Type of artifacts that are being collected.
+        :type type: MultihostArtifactsType
+        :return: List of artifacts to collect.
+        :rtype: set[str]
+        """
+        pass

--- a/pytest_mh/_private/types.py
+++ b/pytest_mh/_private/types.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import Literal, TypeAlias
 
 
-class MultihostHostOSFamily(Enum):
+class MultihostOSFamily(Enum):
     """
     Host operating system family.
     """

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5,7 +5,13 @@ from pathlib import Path
 
 import pytest
 
-from pytest_mh._private.misc import OperationStatus, invoke_callback, merge_dict, sanitize_path
+from pytest_mh._private.misc import (
+    OperationStatus,
+    invoke_callback,
+    merge_dict,
+    sanitize_path,
+    should_collect_artifacts,
+)
 
 
 @pytest.mark.parametrize(
@@ -150,6 +156,32 @@ def test_sanitize_path(path, expected):
     expected = Path(expected)
     assert sanitize_path(path) == expected
     assert sanitize_path(Path(path)) == expected
+
+
+@pytest.mark.parametrize(
+    "mode, outcome, expected",
+    [
+        ("never", "success", False),
+        ("never", "failed", False),
+        ("never", "error", False),
+        ("never", "unknown", False),
+        ("always", "success", True),
+        ("always", "failed", True),
+        ("always", "error", True),
+        ("always", "unknown", True),
+        ("on-failure", "success", False),
+        ("on-failure", "failed", True),
+        ("on-failure", "error", True),
+        ("on-failure", "unknown", True),
+    ],
+)
+def test_should_collect_artifacts(mode, outcome, expected):
+    assert should_collect_artifacts(mode, outcome) == expected
+
+
+def test_should_collect_artifacts__invalid_mode():
+    with pytest.raises(ValueError):
+        should_collect_artifacts("invalid-mode", "success")
 
 
 def test_OperationStatus():


### PR DESCRIPTION
This is a bigger patchset that adds the ability to get artifacts from
pytest_setup, pytest_teardown and topology_setup and topology_teardown.

It also add the ability to set dynymic logs for this operation as well
as for the test run itself.

It refactors the code quite a bit and reorginizes logs into a directory
tree so we are able to store all the requested artifacts.