### PR TITLE
multihost: avoid using inspect.getmembers in MultihostUtility

### DIFF
--- a/pytest_mh/__init__.py
+++ b/pytest_mh/__init__.py
@@ -15,6 +15,8 @@ from ._private.multihost import (
     MultihostOSFamily,
     MultihostRole,
     MultihostUtility,
+    mh_utility_ignore_use,
+    mh_utility_used,
 )
 from ._private.plugin import MultihostPlugin, pytest_addoption, pytest_configure
 from ._private.topology import Topology, TopologyDomain
@@ -35,6 +37,8 @@ __all__ = [
     "MultihostRole",
     "MultihostTopologyControllerArtifacts",
     "MultihostUtility",
+    "mh_utility_ignore_use",
+    "mh_utility_used",
     "pytest_addoption",
     "pytest_configure",
     "Topology",

--- a/pytest_mh/utils/firewall.py
+++ b/pytest_mh/utils/firewall.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Any, Literal, TypeAlias
 
 from .. import MultihostHost, MultihostRole, MultihostUtility
@@ -21,7 +21,7 @@ PortSpec: TypeAlias = int | tuple[int, ProtocolSpec]
 """Firewall port specification."""
 
 
-class Firewall(ABC, MultihostUtility):
+class Firewall(MultihostUtility):
     """
     Configure host firewall.
 


### PR DESCRIPTION
Using inspect.getmembers calls getattr internally which evalutes
lazy properties as a side effect. This is undesirable and can
cause troubles in some cases.

This patch switches to metaclass magic. It also moves the decorators
outside MultihostUtility class for simpler use.