### PR TITLE
errors: switch to ExceptionGroup

### DIFF
--- a/pytest_mh/_private/artifacts.py
+++ b/pytest_mh/_private/artifacts.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias, get_args
 
 from ..ssh import SSHLog
+from .errors import ArtifactsExceptionGroup
 from .misc import sanitize_path, should_collect_artifacts
 from .types import MultihostOSFamily, MultihostOutcome
 
@@ -249,7 +250,7 @@ class MultihostArtifactsCollector(object):
                 errors.append(e)
 
         if errors:
-            raise Exception(errors)
+            raise ArtifactsExceptionGroup("Unable to collect artifacts from all hosts", errors)
 
         # Sort artifacts by name
         artifacts = sorted(artifacts_set)

--- a/pytest_mh/_private/errors.py
+++ b/pytest_mh/_private/errors.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+
+class ArtifactsExceptionGroup(ExceptionGroup):
+    """
+    One or more exception occurred during artifacts collection.
+    """
+
+    ...
+
+
+class TeardownExceptionGroup(ExceptionGroup):
+    """
+    One or more exception occurred during teardown phase.
+    """
+
+    ...

--- a/pytest_mh/_private/fixtures.py
+++ b/pytest_mh/_private/fixtures.py
@@ -8,6 +8,7 @@ import pytest
 
 from .artifacts import MultihostArtifactsCollectable
 from .data import MultihostItemData
+from .errors import TeardownExceptionGroup
 from .logging import MultihostLogger
 from .marks import TopologyMark
 from .misc import invoke_callback
@@ -284,7 +285,7 @@ class MultihostFixture(object):
                     errors.append(e)
 
         if errors:
-            raise Exception(errors)
+            raise TeardownExceptionGroup("Unable to teardown some roles (role.teardown)", errors)
 
     def _teardown_utils(self) -> None:
         """
@@ -313,7 +314,7 @@ class MultihostFixture(object):
                     errors.append(e)
 
         if errors:
-            raise Exception(errors)
+            raise TeardownExceptionGroup("Unable to teardown some hosts (host.teardown)", errors)
 
     def _teardown_hosts_utils(self) -> None:
         """
@@ -327,7 +328,7 @@ class MultihostFixture(object):
                 errors.append(e)
 
         if errors:
-            raise Exception(errors)
+            raise TeardownExceptionGroup("Unable to exit some utilities (util.__exit__)", errors)
 
     def _pytest_report_teststatus(
         self, report: pytest.CollectReport | pytest.TestReport, config: pytest.Config
@@ -438,7 +439,7 @@ class MultihostFixture(object):
 
         errors = [x for x in errors if x is not None]
         if errors:
-            raise Exception(errors)
+            raise TeardownExceptionGroup("One or more error occurred during test teardown", errors)
 
 
 @pytest.fixture(scope="function")

--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -17,6 +17,7 @@ from .artifacts import (
     MultihostArtifactsType,
     MultihostHostArtifacts,
 )
+from .errors import TeardownExceptionGroup
 from .logging import MultihostHostLogger, MultihostLogger
 from .misc import OperationStatus
 from .topology import Topology
@@ -1195,7 +1196,7 @@ def mh_utility_teardown_dependencies(
                 errors.append(e)
 
     if errors:
-        raise Exception(errors)
+        raise TeardownExceptionGroup("Unable to teardown some utilities (util.teardown)", errors)
 
 
 def mh_utility_enter_dependencies(obj: MultihostRole | MultihostHost, where: str) -> None:
@@ -1235,7 +1236,7 @@ def mh_utility_exit_dependencies(obj: MultihostRole | MultihostHost, where: str)
             errors.append(e)
 
     if errors:
-        raise Exception(errors)
+        raise TeardownExceptionGroup("Unable to exit some utilities (util.__exit__)", errors)
 
 
 def mh_utility_pytest_report_teststatus(

--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -15,6 +15,7 @@ import yaml
 
 from .artifacts import MultihostArtifactsCollectable, MultihostArtifactsType
 from .data import MultihostItemData
+from .errors import TeardownExceptionGroup
 from .fixtures import MultihostFixture
 from .logging import MultihostLogger
 from .marks import TopologyMark
@@ -660,7 +661,7 @@ class MultihostPlugin(object):
                 self.multihost.logger.flush(outcome, f"hosts/{host.hostname}/pytest_teardown.log")
 
         if errors:
-            raise Exception(errors)
+            raise TeardownExceptionGroup("Unable to teardown some hosts (host.pytest_teardown)", errors)
 
     def _setup_topology(self, name: str, controller: TopologyController) -> None:
         # Silent mypy false positive
@@ -724,7 +725,9 @@ class MultihostPlugin(object):
             controller.logger.phase(f"TOPOLOGY TEARDOWN EXIT HOST UTILS DONE :: {name}")
 
             if errors:
-                raise Exception(errors)
+                raise TeardownExceptionGroup(
+                    "Unable to teardown topology (topology_controller.topology_teardown)", errors
+                )
 
             outcome = "passed"
         finally:


### PR DESCRIPTION
python-3.11 brings ExceptionGroup feature which is very useful for
our use case where we need to teardown multiple objects eventhough
some of them failed.

With ExceptionGroup, no exception and its traceback is lost.

See:
https://peps.python.org/pep-0654/