### PR TITLE
plugin: make mh_fixture work with generators

### DIFF
--- a/pytest_mh/_private/plugin.py
+++ b/pytest_mh/_private/plugin.py
@@ -899,8 +899,7 @@ def mh_fixture(scope: Literal["function"] = "function"):
                 mh_args.append(arg)
                 continue
 
-        @wraps(fn)
-        def wrapper(mh: MultihostFixture, *args, **kwargs):
+        def call_fixture(mh: MultihostFixture, *args, **kwargs):
             if "mh" in full_sig.parameters:
                 kwargs["mh"] = mh
 
@@ -911,6 +910,24 @@ def mh_fixture(scope: Literal["function"] = "function"):
                 kwargs[arg] = mh.fixtures[arg]
 
             return fn(*args, **kwargs)
+
+        @wraps(fn)
+        def wrapper_normal(mh: MultihostFixture, *args, **kwargs):
+            return call_fixture(mh, *args, **kwargs)
+
+        @wraps(fn)
+        def wrapper_yield(mh: MultihostFixture, *args, **kwargs):
+            gen = call_fixture(mh, *args, **kwargs)
+            yield next(gen)
+            try:
+                yield next(gen)
+            except StopIteration:
+                pass
+
+        # Select wrapper
+        wrapper = wrapper_normal
+        if inspect.isgeneratorfunction(fn):
+            wrapper = wrapper_yield
 
         # Bound multihost parameters
         cb = wraps(fn)(partial(wrapper, **{arg: None for arg in mh_args}))


### PR DESCRIPTION
The following pytest fixture syntax is now supported.

```
@mh_fixture
def fixt(client: Client):
    setup()
    yield
    teardown()
```