### PR TITLE
multihost: add config field to MultihostDomain and MultihostConfig as well

### DIFF
--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -176,6 +176,9 @@ class MultihostConfig(ABC):
         self.confdict: dict[str, Any] = confdict
         """Multihost configuration dictionary given to the constructor."""
 
+        self.config: dict[str, Any] = confdict.get("config", {})
+        """Custom configuration."""
+
         self.logger: MultihostLogger = logger
         """Multihost logger"""
 
@@ -301,6 +304,9 @@ class MultihostDomain(ABC, Generic[ConfigType]):
 
         self.confdict: dict[str, Any] = confdict
         """Multihost domain configuration dictionary given to the constructor."""
+
+        self.config: dict[str, Any] = confdict.get("config", {})
+        """Custom configuration."""
 
         self.mh_config: ConfigType = config
         """Multihost configuration"""


### PR DESCRIPTION
This is reserved for custom configuration options to avoid potential
name collisions if we add more stuff.