### PR TITLE
artifacts: rename type to artifacts_type in get_artifacts_list

### DIFF
--- a/pytest_mh/_private/artifacts.py
+++ b/pytest_mh/_private/artifacts.py
@@ -149,7 +149,7 @@ class MultihostArtifactsCollectable(Protocol):
     Protocol: object supports artifacts collection.
     """
 
-    def get_artifacts_list(self, host: MultihostHost, type: MultihostArtifactsType) -> set[str]:
+    def get_artifacts_list(self, host: MultihostHost, artifacts_type: MultihostArtifactsType) -> set[str]:
         """
         Return the list of artifacts to collect.
 
@@ -160,8 +160,8 @@ class MultihostArtifactsCollectable(Protocol):
 
         :param host: Host where the artifacts are being collected.
         :type host: MultihostHost
-        :param type: Type of artifacts that are being collected.
-        :type type: MultihostArtifactsType
+        :param artifacts_type: Type of artifacts that are being collected.
+        :type artifacts_type: MultihostArtifactsType
         :return: List of artifacts to collect.
         :rtype: set[str]
         """
@@ -212,7 +212,7 @@ class MultihostArtifactsCollector(object):
 
     def collect(
         self,
-        type: MultihostArtifactsType,
+        artifacts_type: MultihostArtifactsType,
         *,
         path: str,
         outcome: MultihostOutcome,
@@ -221,8 +221,8 @@ class MultihostArtifactsCollector(object):
         """
         Collect artifacts to $artifacts_dir/$path/$collection_path.
 
-        :param type: Artifacts type.
-        :type type: MultihostArtifactsType
+        :param artifacts_type: Artifacts type.
+        :type artifacts_type: MultihostArtifactsType
         :param path: Artifacts path relative to artifacts directory.
         :type path: str
         :param outcome: Test or operation outcome.
@@ -245,7 +245,7 @@ class MultihostArtifactsCollector(object):
         artifacts_set: set[str] = set()
         for obj in collect_objects:
             try:
-                artifacts_set.update(obj.get_artifacts_list(self.host, type))
+                artifacts_set.update(obj.get_artifacts_list(self.host, artifacts_type))
             except Exception as e:
                 errors.append(e)
 

--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -583,7 +583,7 @@ class MultihostHost(Generic[DomainType], metaclass=_MultihostHostMeta):
         """
         pass
 
-    def get_artifacts_list(self, host: MultihostHost, type: MultihostArtifactsType) -> set[str]:
+    def get_artifacts_list(self, host: MultihostHost, artifacts_type: MultihostArtifactsType) -> set[str]:
         """
         Return the list of artifacts to collect.
 
@@ -594,12 +594,12 @@ class MultihostHost(Generic[DomainType], metaclass=_MultihostHostMeta):
 
         :param host: Host where the artifacts are being collected.
         :type host: MultihostHost
-        :param type: Type of artifacts that are being collected.
-        :type type: MultihostArtifactsType
+        :param artifacts_type: Type of artifacts that are being collected.
+        :type artifacts_type: MultihostArtifactsType
         :return: List of artifacts to collect.
         :rtype: set[str]
         """
-        return self.configured_artifacts.get(type) | self.artifacts.get(type)
+        return self.configured_artifacts.get(artifacts_type) | self.artifacts.get(artifacts_type)
 
     def get_connection(self, shell: Shell) -> Connection:
         """
@@ -682,7 +682,7 @@ class MultihostRole(Generic[HostType], metaclass=_MultihostRoleMeta):
         """
         pass
 
-    def get_artifacts_list(self, host: MultihostHost, type: MultihostArtifactsType) -> set[str]:
+    def get_artifacts_list(self, host: MultihostHost, artifacts_type: MultihostArtifactsType) -> set[str]:
         """
         Return the list of artifacts to collect.
 
@@ -693,8 +693,8 @@ class MultihostRole(Generic[HostType], metaclass=_MultihostRoleMeta):
 
         :param host: Host where the artifacts are being collected.
         :type host: MultihostHost
-        :param type: Type of artifacts that are being collected.
-        :type type: MultihostArtifactsType
+        :param artifacts_type: Type of artifacts that are being collected.
+        :type artifacts_type: MultihostArtifactsType
         :return: List of artifacts to collect.
         :rtype: set[str]
         """
@@ -778,7 +778,7 @@ class MultihostUtility(Generic[HostType], metaclass=_MultihostUtilityMeta):
         """
         pass
 
-    def get_artifacts_list(self, host: MultihostHost, type: MultihostArtifactsType) -> set[str]:
+    def get_artifacts_list(self, host: MultihostHost, artifacts_type: MultihostArtifactsType) -> set[str]:
         """
         Return the list of artifacts to collect.
 
@@ -789,8 +789,8 @@ class MultihostUtility(Generic[HostType], metaclass=_MultihostUtilityMeta):
 
         :param host: Host where the artifacts are being collected.
         :type host: MultihostHost
-        :param type: Type of artifacts that are being collected.
-        :type type: MultihostArtifactsType
+        :param artifacts_type: Type of artifacts that are being collected.
+        :type artifacts_type: MultihostArtifactsType
         :return: List of artifacts to collect.
         :rtype: set[str]
         """

--- a/pytest_mh/_private/topology_controller.py
+++ b/pytest_mh/_private/topology_controller.py
@@ -282,7 +282,7 @@ class TopologyController(Generic[ConfigType]):
 
         return self.__hosts
 
-    def get_artifacts_list(self, host: MultihostHost, type: MultihostArtifactsType) -> set[str]:
+    def get_artifacts_list(self, host: MultihostHost, artifacts_type: MultihostArtifactsType) -> set[str]:
         """
         Return the list of artifacts to collect.
 
@@ -293,12 +293,12 @@ class TopologyController(Generic[ConfigType]):
 
         :param host: Host where the artifacts are being collected.
         :type host: MultihostHost
-        :param type: Type of artifacts that are being collected.
-        :type type: MultihostArtifactsType
+        :param artifacts_type: Type of artifacts that are being collected.
+        :type artifacts_type: MultihostArtifactsType
         :return: List of artifacts to collect.
         :rtype: set[str]
         """
-        return self.artifacts.get(host, type)
+        return self.artifacts.get(host, artifacts_type)
 
     def set_artifacts(self, *args, **kwargs) -> None:
         """

--- a/pytest_mh/utils/coredumpd.py
+++ b/pytest_mh/utils/coredumpd.py
@@ -125,14 +125,14 @@ class Coredumpd(MultihostUtility[MultihostHost]):
 
         return (pid, timestamp)
 
-    def get_artifacts_list(self, host: MultihostHost, type: MultihostArtifactsType) -> set[str]:
+    def get_artifacts_list(self, host: MultihostHost, artifacts_type: MultihostArtifactsType) -> set[str]:
         """
         Dump backtrace and other information from generated core files for easy access.
 
         :param host: Host where the artifacts are being collected.
         :type host: MultihostHost
-        :param type: Type of artifacts that are being collected.
-        :type type: MultihostArtifactsType
+        :param artifacts_type: Type of artifacts that are being collected.
+        :type artifacts_type: MultihostArtifactsType
         :return: List of artifacts to collect.
         :rtype: set[str]
         """

--- a/pytest_mh/utils/journald.py
+++ b/pytest_mh/utils/journald.py
@@ -39,14 +39,14 @@ class JournaldUtils(MultihostUtility):
         """
         self._test_start = self.now
 
-    def get_artifacts_list(self, host: MultihostHost, type: MultihostArtifactsType) -> set[str]:
+    def get_artifacts_list(self, host: MultihostHost, artifacts_type: MultihostArtifactsType) -> set[str]:
         """
         Dump journald into file that can be collected.
 
         :param host: Host where the artifacts are being collected.
         :type host: MultihostHost
-        :param type: Type of artifacts that are being collected.
-        :type type: MultihostArtifactsType
+        :param artifacts_type: Type of artifacts that are being collected.
+        :type artifacts_type: MultihostArtifactsType
         :return: List of artifacts to collect.
         :rtype: set[str]
         """


### PR DESCRIPTION
...to avoid shadowing global `type()`.