### PR TITLE
multihost: add MultihostBackupHost and BackupTopologyController

### DIFF
--- a/pytest_mh/__init__.py
+++ b/pytest_mh/__init__.py
@@ -9,6 +9,7 @@ from ._private.data import MultihostItemData
 from ._private.fixtures import MultihostFixture, mh
 from ._private.marks import KnownTopologyBase, KnownTopologyGroupBase, TopologyMark
 from ._private.multihost import (
+    MultihostBackupHost,
     MultihostConfig,
     MultihostDomain,
     MultihostHost,
@@ -34,6 +35,7 @@ __all__ = [
     "MultihostDomain",
     "MultihostFixture",
     "MultihostHost",
+    "MultihostBackupHost",
     "MultihostHostArtifacts",
     "MultihostItemData",
     "MultihostOSFamily",

--- a/pytest_mh/__init__.py
+++ b/pytest_mh/__init__.py
@@ -24,7 +24,7 @@ from ._private.multihost import (
 )
 from ._private.plugin import MultihostPlugin, mh_fixture, pytest_addoption, pytest_configure
 from ._private.topology import Topology, TopologyDomain
-from ._private.topology_controller import TopologyController
+from ._private.topology_controller import BackupTopologyController, TopologyController
 
 __all__ = [
     "mh",
@@ -53,6 +53,7 @@ __all__ = [
     "pytest_configure",
     "Topology",
     "TopologyController",
+    "BackupTopologyController",
     "TopologyDomain",
     "TopologyMark",
 ]


### PR DESCRIPTION
MultihostBackupHost: This is a base host that provides automatic host backup and restore functionality.

BackupTopologyController: This controller provides automatic backup and restore of the topology hosts.
