### PR TITLE
journald: set initial cursor

### DIFF
--- a/pytest_mh/utils/journald.py
+++ b/pytest_mh/utils/journald.py
@@ -38,6 +38,7 @@ class JournaldUtils(MultihostUtility):
         Called before execution of each test.
         """
         self._test_start = self.now
+        self._cursor = self._test_start
 
     def get_artifacts_list(self, host: MultihostHost, artifacts_type: MultihostArtifactsType) -> set[str]:
         """


### PR DESCRIPTION
Otherwise an empty timestamp is used in "journalctl" as "since".