### PR TITLE
mh: gracefully handle exception in one of the skip callbacks

### DIFF
--- a/pytest_mh/_private/errors.py
+++ b/pytest_mh/_private/errors.py
@@ -15,3 +15,11 @@ class TeardownExceptionGroup(ExceptionGroup):
     """
 
     ...
+
+
+class SkipCallbackExceptionGroup(ExceptionGroup):
+    """
+    One or more exception occurred during skip callback phase.
+    """
+
+    ...

--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -1365,6 +1365,8 @@ def mh_utility_exit_dependencies(obj: MultihostRole | MultihostHost, where: str)
         except Exception as e:
             errors.append(e)
 
+        util._op_state.clear(f"__enter__{where}")
+
     if errors:
         raise TeardownExceptionGroup("Unable to exit some utilities (util.__exit__)", errors)
 


### PR DESCRIPTION
```
4baa3e2 (Pavel Březina, 33 minutes ago)
   mh: gracefully handle exception in one of the skip callbacks

   This will handle an exception inside skip callback nicely and stores logs
   inside skip.log inside a test.log.

49ba7c1 (Pavel Březina, 6 minutes ago)
   utils: clear state on exit

   Otherwise host utils will have lingering state from previous test runs.
---

If an error corrured insinde a skip callback, we got broken and attempted to call exit on utils that were not entered. The first commit avoids the condition to happen and the teardown is not run at all, which makes sense since we did not run setup. The second commit fixes the reason why we attempted to call exit to avoid it in other possible situations.

Reproducer:
https://github.com/pbrezina/sssd/tree/ci-exit

```
pytest --mh-config=mhc.yaml -k "test_passkey__check_tgt or test_passkey__ipa_server_offline" -vvv
```