### PR TITLE
conn: use /usr/bin/env to run the shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,9 @@ jobs:
     - name: Workaround https://github.com/actions/runner-images/issues/7753
       shell: bash
       run: |
-        curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-3_amd64.deb
-        sudo dpkg -i containernetworking-plugins_1.1.1+ds1-3_amd64.deb
-        rm --force containernetworking-plugins_1.1.1+ds1-3_amd64.deb
+        curl -O http://archive.ubuntu.com/ubuntu/pool/universe/g/golang-github-containernetworking-plugins/containernetworking-plugins_1.1.1+ds1-3ubuntu0.24.04.2_amd64.deb
+        sudo dpkg -i containernetworking-plugins_1.1.1+ds1-3ubuntu0.24.04.2_amd64.deb
+        rm --force containernetworking-plugins_1.1.1+ds1-3ubuntu0.24.04.2_amd64.deb
 
     - name: Workaround https://github.com/containers/crun/issues/1308
       shell: bash

--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -469,8 +469,6 @@ class MultihostHost(Generic[DomainType], metaclass=_MultihostHostMeta):
         :type domain: DomainType
         :param confdict: Host configuration as a dictionary.
         :type confdict: dict[str, Any]
-        :param shell: Shell used in SSH connection, defaults to '/usr/bin/bash -c'.
-        :type shell: str
         """
         self._op_state: OperationStatus = OperationStatus()
         """Keep state of setup and teardown methods."""

--- a/pytest_mh/conn/__init__.py
+++ b/pytest_mh/conn/__init__.py
@@ -1037,7 +1037,7 @@ class Bash(Shell):
     """
 
     def __init__(self) -> None:
-        super().__init__("bash", "/usr/bin/bash -c")
+        super().__init__("bash", "/usr/bin/env bash -c")
 
     def build_command_line(self, script: str, *, cwd: str | None, env: dict[str, Any]) -> str:
         full_script = self._add_cwd_and_env(script, cwd=cwd, env=env)
@@ -1065,7 +1065,7 @@ class Bash(Shell):
 
     def _escape_single_quotes(self, command: str) -> str:
         """
-        We call the command as `bash -c '$command'`.
+        We call the command as `/usr/bin/env bash -c '$command'`.
 
         We need to escape ' inside the script to make it work correctly.
         """

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -24,7 +24,7 @@ def test_conn__shell_bash__script(input: str, expected: str):
     shell = Bash()
 
     assert shell.name == "bash"
-    assert shell.shell_command == "/usr/bin/bash -c"
+    assert shell.shell_command == "/usr/bin/env bash -c"
 
     cmd = shell.build_command_line(input, cwd=None, env={})
     assert cmd == f"{shell.shell_command} '{expected}'"
@@ -34,7 +34,7 @@ def test_conn__shell_bash__cwd():
     shell = Bash()
 
     assert shell.name == "bash"
-    assert shell.shell_command == "/usr/bin/bash -c"
+    assert shell.shell_command == "/usr/bin/env bash -c"
 
     cmd = shell.build_command_line("echo hello world", cwd="/home/test", env={})
     expected = textwrap.dedent(
@@ -51,7 +51,7 @@ def test_conn__shell_bash__env():
     shell = Bash()
 
     assert shell.name == "bash"
-    assert shell.shell_command == "/usr/bin/bash -c"
+    assert shell.shell_command == "/usr/bin/env bash -c"
 
     cmd = shell.build_command_line("echo hello world", cwd=None, env={"HELLO": "WORLD", "JOHN": "DOE"})
     expected = textwrap.dedent(
@@ -69,7 +69,7 @@ def test_conn__shell_bash__cwd_env():
     shell = Bash()
 
     assert shell.name == "bash"
-    assert shell.shell_command == "/usr/bin/bash -c"
+    assert shell.shell_command == "/usr/bin/env bash -c"
 
     cmd = shell.build_command_line("echo hello world", cwd="/home/test", env={"HELLO": "WORLD", "JOHN": "DOE"})
     expected = textwrap.dedent(


### PR DESCRIPTION
To make the code more portable to distributions that don't have bash in
/usr/bin.