### PR TITLE
multihost: add conn to role and utility as a shortcut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get update
+        sudo apt-get install -y libssh-dev
+
         python -m pip install --upgrade pip
         pip install tox tox-gh
     - name: Prepare tox environment and install packages

--- a/docs/articles/extending/multihost-roles.rst
+++ b/docs/articles/extending/multihost-roles.rst
@@ -128,7 +128,7 @@ during teardown.
             Journald utilities.
             """
 
-            self.cli: CLIBuilder = CLIBuilder(self.host.conn)
+            self.cli: CLIBuilder = CLIBuilder(self.conn)
             """
             CLI builder helper.
             """
@@ -161,7 +161,7 @@ during teardown.
             # Delete users that we added
             if self._users:
                 cmd = "\n".join([f"userdel '{x}' --force --remove" for x in self._users]) + "\n"
-                self.host.conn.run("set -e\n\n" + cmd)
+                self.conn.run("set -e\n\n" + cmd)
 
             super().teardown()
 
@@ -208,7 +208,7 @@ during teardown.
 
             passwd = f" && passwd --stdin '{name}'" if password else ""
             self.logger.info(f'Creating local user "{name}" on {self.host.hostname}')
-            self.host.conn.run(self.cli.command("useradd", args) + passwd, input=password, log_level=ProcessLogLevel.Error)
+            self.conn.run(self.cli.command("useradd", args) + passwd, input=password, log_level=ProcessLogLevel.Error)
 
             self._users.append(name)
 

--- a/docs/articles/extending/multihost-utilities.rst
+++ b/docs/articles/extending/multihost-utilities.rst
@@ -71,7 +71,7 @@ cleans up after itself and to share this code between multiple roles.
 
             if self._users:
                 cmd = "\n".join([f"userdel '{x}' --force --remove" for x in self._users]) + "\n"
-                self.host.conn.run("set -e\n\n" + cmd)
+                self.conn.run("set -e\n\n" + cmd)
 
             super().teardown()
 
@@ -118,7 +118,7 @@ cleans up after itself and to share this code between multiple roles.
 
             passwd = f" && passwd --stdin '{name}'" if password else ""
             self.logger.info(f'Creating local user "{name}" on {self.host.hostname}')
-            self.host.conn.run(self.cli.command("useradd", args) + passwd, input=password, log_level=ProcessLogLevel.Error)
+            self.conn.run(self.cli.command("useradd", args) + passwd, input=password, log_level=ProcessLogLevel.Error)
 
             self._users.append(name)
 
@@ -315,7 +315,7 @@ example.
             """
             if self._users:
                 cmd = "\n".join([f"userdel '{x}' --force --remove" for x in self._users]) + "\n"
-                self.host.conn.run("set -e\n\n" + cmd)
+                self.conn.run("set -e\n\n" + cmd)
 
             self._users = self._states.pop()
 
@@ -362,7 +362,7 @@ example.
 
             passwd = f" && passwd --stdin '{name}'" if password else ""
             self.logger.info(f'Creating local user "{name}" on {self.host.hostname}')
-            self.host.conn.run(self.cli.command("useradd", args) + passwd, input=password, log_level=ProcessLogLevel.Error)
+            self.conn.run(self.cli.command("useradd", args) + passwd, input=password, log_level=ProcessLogLevel.Error)
 
             self._users.append(name)
 

--- a/docs/articles/running-commands/blocking-calls.rst
+++ b/docs/articles/running-commands/blocking-calls.rst
@@ -20,19 +20,19 @@ return code, standard output and standard error output.
             """
             Run a single line script code.
             """
-            return self.host.conn.run("echo 'Hello World'")
+            return self.conn.run("echo 'Hello World'")
 
         def say_hello_argv(self) -> ProcessResult:
             """
             Execute command by passing list of arguments.
             """
-            return self.host.conn.exec(["echo", "Hello World"])
+            return self.conn.exec(["echo", "Hello World"])
 
         def say_script(self) -> ProcessResult:
             """
             Execute a multiline script code.
             """
-            return self.host.conn.run(
+            return self.conn.run(
                 """
                 set -ex
 
@@ -44,7 +44,7 @@ return code, standard output and standard error output.
             """
             You can also pass input data.
             """
-            return self.host.conn.run("cat", input="Hello World")
+            return self.conn.run("cat", input="Hello World")
 
     @pytest.mark.topology(...)
     def test_hello(example: ExampleRole) -> None:
@@ -68,7 +68,7 @@ overwrite the behaviour with ``raise_on_error`` argument.
 .. code-block:: python
     :caption: Example: Do not raise exception on non-zero return code
 
-    result = self.host.conn.run("echo 'Hello World'", raise_on_error=False)
+    result = self.conn.run("echo 'Hello World'", raise_on_error=False)
     if result.rc not in (0, 1):
         # Raise ProcessError if rc was not 0 or 1
         result.throw()
@@ -83,7 +83,7 @@ overwrite the behaviour with ``raise_on_error`` argument.
     .. code-block:: python
         :caption: Example: Custom log level
 
-        self.host.conn.run(
+        self.conn.run(
             "echo 'Hello World'",
             log_level=ProcessLogLevel.Error
         )

--- a/docs/articles/running-commands/non-blocking-calls.rst
+++ b/docs/articles/running-commands/non-blocking-calls.rst
@@ -30,7 +30,7 @@ which represents a running process. You can write to
 
     @pytest.mark.topology(...)
     def test_hello(example: ExampleRole) -> None:
-        process = example.host.conn.async_run("cat")
+        process = example.conn.async_run("cat")
 
         process.stdin.write("Hello\n")
         assert next(process.stdout) == "Hello"

--- a/example/framework/utils/local_users.py
+++ b/example/framework/utils/local_users.py
@@ -54,7 +54,7 @@ class LocalUsersUtils(MultihostUtility[MultihostHost]):
             cmd += "\n"
 
         if cmd:
-            self.host.conn.run("set -e\n\n" + cmd)
+            self.conn.run("set -e\n\n" + cmd)
 
         super().teardown()
 
@@ -138,7 +138,7 @@ class LocalUser(User):
 
         passwd = f" && passwd --stdin '{self.name}'" if password else ""
         self.util.logger.info(f'Creating local user "{self.name}"')
-        self.util.host.conn.run(
+        self.util.conn.run(
             self.util.cli.command("useradd", args) + passwd, input=password, log_level=ProcessLogLevel.Error
         )
 
@@ -180,7 +180,7 @@ class LocalGroup(Group):
         }
 
         self.util.logger.info(f'Creating local group "{self.name}"')
-        self.util.host.conn.run(self.util.cli.command("groupadd", args), log_level=ProcessLogLevel.Silent)
+        self.util.conn.run(self.util.cli.command("groupadd", args), log_level=ProcessLogLevel.Silent)
         self.util._groups.append(self.name)
 
         return self
@@ -200,7 +200,7 @@ class LocalGroup(Group):
             return self
 
         cmd = "\n".join([f"groupmems --group '{self.name}' --add '{x.name}'" for x in members])
-        self.util.host.conn.run("set -ex\n" + cmd, log_level=ProcessLogLevel.Error)
+        self.util.conn.run("set -ex\n" + cmd, log_level=ProcessLogLevel.Error)
 
         return self
 
@@ -219,6 +219,6 @@ class LocalGroup(Group):
             return self
 
         cmd = "\n".join([f"groupmems --group '{self.name}' --delete '{x.name}'" for x in members])
-        self.util.host.conn.run("set -ex\n" + cmd, log_level=ProcessLogLevel.Error)
+        self.util.conn.run("set -ex\n" + cmd, log_level=ProcessLogLevel.Error)
 
         return self

--- a/example/framework/utils/sudo.py
+++ b/example/framework/utils/sudo.py
@@ -27,9 +27,7 @@ class SUDOUtils(MultihostUtility[MultihostHost]):
         :return: True if the command was successful, False if the command failed or the user can not run sudo.
         :rtype: bool
         """
-        result = self.host.conn.run(
-            f'su - "{username}" -c "sudo --stdin {command}"', input=password, raise_on_error=False
-        )
+        result = self.conn.run(f'su - "{username}" -c "sudo --stdin {command}"', input=password, raise_on_error=False)
 
         return result.rc == 0
 
@@ -46,7 +44,7 @@ class SUDOUtils(MultihostUtility[MultihostHost]):
         :return: True if the user can run sudo and allowed commands match expected commands (if set), False otherwise.
         :rtype: bool
         """
-        result = self.host.conn.run(f'su - "{username}" -c "sudo --stdin -l"', input=password, raise_on_error=False)
+        result = self.conn.run(f'su - "{username}" -c "sudo --stdin -l"', input=password, raise_on_error=False)
         if result.rc != 0:
             return False
 

--- a/pytest_mh/_private/multihost.py
+++ b/pytest_mh/_private/multihost.py
@@ -819,6 +819,9 @@ class MultihostRole(Generic[HostType], metaclass=_MultihostRoleMeta):
         self.role: str = role
         self.host: HostType = host
 
+        self.conn: Connection[Process[ProcessResult, ProcessInputBuffer], ProcessResult[ProcessError]] = host.conn
+        """Connection to the host."""
+
         self.logger: MultihostLogger = self.host.logger
         """Multihost logger."""
 
@@ -911,6 +914,9 @@ class MultihostUtility(Generic[HostType], metaclass=_MultihostUtilityMeta):
         """
         self.host: HostType = host
         """Multihost host."""
+
+        self.conn: Connection[Process[ProcessResult, ProcessInputBuffer], ProcessResult[ProcessError]] = host.conn
+        """Connection to the host."""
 
         self.logger: MultihostLogger = self.host.logger
         """Multihost logger."""

--- a/pytest_mh/utils/auditd.py
+++ b/pytest_mh/utils/auditd.py
@@ -59,7 +59,7 @@ class Auditd(MultihostUtility[MultihostHost]):
         """
         super().setup()
 
-        result = self.host.conn.run(
+        result = self.conn.run(
             """
             set -e
 
@@ -85,7 +85,7 @@ class Auditd(MultihostUtility[MultihostHost]):
         Restore previous audit logs from backup and remove the backup.
         """
         if self._backup is not None:
-            self.host.conn.run(
+            self.conn.run(
                 f"""
                 set -e
 
@@ -122,7 +122,7 @@ class Auditd(MultihostUtility[MultihostHost]):
 
         self.logger.info("Checking for AVC denials")
 
-        result = self.host.conn.run(
+        result = self.conn.run(
             "ausearch --input-logs -m AVC,USER_AVC", raise_on_error=False, log_level=ProcessLogLevel.Silent
         )
         if result.rc:

--- a/pytest_mh/utils/coredumpd.py
+++ b/pytest_mh/utils/coredumpd.py
@@ -94,9 +94,7 @@ class Coredumpd(MultihostUtility[MultihostHost]):
         :rtype: list[str]
         """
         # List the folder, exit with 0 if it does not exist (no core files were produced)
-        result = self.host.conn.run(
-            f"[ -d '{self.path}' ] && ls -N -1 '{self.path}' || :", log_level=ProcessLogLevel.Error
-        )
+        result = self.conn.run(f"[ -d '{self.path}' ] && ls -N -1 '{self.path}' || :", log_level=ProcessLogLevel.Error)
 
         return result.stdout_lines
 
@@ -151,7 +149,7 @@ class Coredumpd(MultihostUtility[MultihostHost]):
                 continue
 
             # Dump the information
-            self.host.conn.run(
+            self.conn.run(
                 rf"""
                 journalctl --output=verbose          \
                     'COREDUMP_PID={pid}'             \

--- a/pytest_mh/utils/fs.py
+++ b/pytest_mh/utils/fs.py
@@ -57,7 +57,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
 
             cmd = "\n".join(reversed(self.__rollback))
             if cmd:
-                self.host.conn.run(cmd, log_level=ProcessLogLevel.Error)
+                self.conn.run(cmd, log_level=ProcessLogLevel.Error)
 
         self.__rollback, self.__backup = self.__states.pop()
 
@@ -76,7 +76,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         """
         self.backup(path)
         self.logger.info(f'Creating directory "{path}"')
-        self.host.conn.run(
+        self.conn.run(
             f"""
                 set -ex
                 rm -fr '{path}'
@@ -104,7 +104,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         backup_exists = path in self.__backup
         self.backup(path)
         self.logger.info(f'Creating directory "{path}" (with parents)')
-        result = self.host.conn.run(
+        result = self.conn.run(
             f"""
                 set -ex
                 rm -fr '{path}'
@@ -151,7 +151,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         """
 
         self.logger.info("Creating temporary file")
-        result = self.host.conn.run(
+        result = self.conn.run(
             """
                 set -ex
                 tmp=`mktemp /tmp/mh.fs.rollback.XXXXXXXXX`
@@ -173,11 +173,11 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
                 contents = textwrap.dedent(contents).strip()
 
             self.logger.info(f'Writing file "{tmpfile}"', extra={"data": {"Contents": contents}})
-            self.host.conn.run(f"cat > '{tmpfile}'", input=contents, log_level=ProcessLogLevel.Error)
+            self.conn.run(f"cat > '{tmpfile}'", input=contents, log_level=ProcessLogLevel.Error)
 
         attrs = self.__gen_chattrs(tmpfile, mode=mode, user=user, group=group)
         if attrs:
-            self.host.conn.run(attrs, log_level=ProcessLogLevel.Error)
+            self.conn.run(attrs, log_level=ProcessLogLevel.Error)
 
         return tmpfile
 
@@ -191,7 +191,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         self.backup(path)
         self.logger.info(f'Removing file "{path}"')
 
-        self.host.conn.run(
+        self.conn.run(
             f"""
                 set -ex
                 rm -fr '{path}'
@@ -209,7 +209,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         :rtype: str
         """
         self.logger.info(f'Reading file "{path}"')
-        result = self.host.conn.exec(["cat", path], log_level=ProcessLogLevel.Error)
+        result = self.conn.exec(["cat", path], log_level=ProcessLogLevel.Error)
 
         return result.stdout
 
@@ -223,7 +223,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         :rtype: bool
         """
         self.logger.info(f'Checking if "{path}" exists')
-        result = self.host.conn.exec(["ls", path], log_level=ProcessLogLevel.Error, raise_on_error=False)
+        result = self.conn.exec(["ls", path], log_level=ProcessLogLevel.Error, raise_on_error=False)
 
         if result.rc == 0:
             return True
@@ -262,7 +262,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         self.backup(path)
         self.logger.info(f'Writing file "{path}"', extra={"data": {"Contents": contents}})
 
-        self.host.conn.run(
+        self.conn.run(
             f"""
                 set -ex
 
@@ -300,7 +300,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         self.backup(path)
         self.logger.info(f'Appending to file "{path}"', extra={"data": {"Contents": contents}})
 
-        self.host.conn.run(
+        self.conn.run(
             f"""
                 set -ex
                 cat >> '{path}'
@@ -334,7 +334,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         self.backup(path)
         self.logger.info(f'Touching file "{path}"')
 
-        self.host.conn.run(
+        self.conn.run(
             f"""
                 set -ex
                 touch '{path}'
@@ -360,7 +360,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         self.backup(path)
         self.logger.info(f'Truncating file "{path}"', extra={"data": {"Size": size}})
 
-        self.host.conn.run(
+        self.conn.run(
             f"""
                 set -ex
                 truncate -s '{size}' '{path}'
@@ -396,7 +396,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         self.backup(dstpath)
         self.logger.info(f'Copying file "{srcpath}" to "{dstpath}"')
 
-        self.host.conn.run(
+        self.conn.run(
             f"""
                 set -ex
                 cp --archive '{srcpath}' '{dstpath}'
@@ -433,7 +433,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         with open(local_path, "rb") as f:
             encoded = base64.b64encode(f.read()).decode("utf-8")
 
-        self.host.conn.run(
+        self.conn.run(
             f"""
                 set -ex
 
@@ -476,7 +476,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         with open(local_path, "rb") as f:
             encoded = base64.b64encode(f.read()).decode("utf-8")
 
-        self.host.conn.run(f"base64 --decode > '{tmp_path}'", input=encoded, log_level=ProcessLogLevel.Error)
+        self.conn.run(f"base64 --decode > '{tmp_path}'", input=encoded, log_level=ProcessLogLevel.Error)
 
         return tmp_path
 
@@ -490,7 +490,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         :type local_path: str
         """
         self.logger.info(f'Downloading file "{self.host.hostname}:{remote_path}" to "{local_path}"')
-        result = self.host.conn.exec(["base64", remote_path], log_level=ProcessLogLevel.Error)
+        result = self.conn.exec(["base64", remote_path], log_level=ProcessLogLevel.Error)
         with open(local_path, "wb") as f:
             f.write(base64.b64decode(result.stdout))
 
@@ -508,7 +508,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         self.logger.info(
             f'Downloading files from {self.host.hostname} to "{local_path}"', extra={"data": {"Paths": paths}}
         )
-        result = self.host.conn.run(
+        result = self.conn.run(
             f"""
             tmp=`mktemp /tmp/mh.fs.download_files.XXXXXXXXX`
             tar -czvf "$tmp" {' '.join([f'$(compgen -G "{path}")' for path in paths])} &> /dev/null
@@ -543,7 +543,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
             return True
 
         self.logger.info(f'Creating a backup of "{path}"')
-        result = self.host.conn.run(
+        result = self.conn.run(
             f"""
         set -ex
 
@@ -594,7 +594,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         action, state = item
 
         self.logger.info(f'Restoring "{path}" from backup ({state})')
-        self.host.conn.run(action, log_level=ProcessLogLevel.Error)
+        self.conn.run(action, log_level=ProcessLogLevel.Error)
 
         self.__rollback.remove(action)
         del self.__backup[path]
@@ -650,7 +650,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         if chars:
             args.append("-m")
 
-        return self.host.conn.exec(["wc", *args, file], log_level=ProcessLogLevel.Error)
+        return self.conn.exec(["wc", *args, file], log_level=ProcessLogLevel.Error)
 
     def diff(
         self,
@@ -689,7 +689,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         if ignore_case:
             args.append("--ignore-case")
 
-        return self.host.conn.exec(["diff", *args, path1, path2], raise_on_error=False)
+        return self.conn.exec(["diff", *args, path1, path2], raise_on_error=False)
 
     def chmod(self, mode: str, path: str, args: list[str] | None = None) -> ProcessResult:
         """
@@ -709,7 +709,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         self.backup(path)
         self.logger.info(f'Changing mode to "{mode}" for "{path}"')
         args = args if args else []
-        return self.host.conn.exec(["chmod", *args, mode, path], log_level=ProcessLogLevel.Error)
+        return self.conn.exec(["chmod", *args, mode, path], log_level=ProcessLogLevel.Error)
 
     def chown(
         self, path: str, user: str | None = None, group: str | None = None, args: list[str] | None = None
@@ -737,7 +737,7 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         args = args if args else []
         mode = f"{user}" if user else ""
         mode += f":{group}" if group else ""
-        return self.host.conn.exec(["chown", mode, *path.split(), *args], log_level=ProcessLogLevel.Error)
+        return self.conn.exec(["chown", mode, *path.split(), *args], log_level=ProcessLogLevel.Error)
 
     def sed(self, command: str, path: str, args: list[str] | None = None) -> ProcessResult:
         """
@@ -756,4 +756,4 @@ class LinuxFileSystem(MultihostReentrantUtility[MultihostHost]):
         self.backup(path)
         self.logger.info(f"Running sed {command} on {path}")
         args = args if args else []
-        return self.host.conn.exec(["sed", *args, command, path], log_level=ProcessLogLevel.Error)
+        return self.conn.exec(["sed", *args, command, path], log_level=ProcessLogLevel.Error)

--- a/pytest_mh/utils/journald.py
+++ b/pytest_mh/utils/journald.py
@@ -31,7 +31,7 @@ class JournaldUtils(MultihostUtility[MultihostHost]):
         :return: Current date and time that can be used to filter the journal.
         :rtype: str
         """
-        return self.host.conn.exec(["date", "+%Y-%m-%d %H:%M:%S.%N"], log_level=ProcessLogLevel.Error).stdout.strip()
+        return self.conn.exec(["date", "+%Y-%m-%d %H:%M:%S.%N"], log_level=ProcessLogLevel.Error).stdout.strip()
 
     def setup(self) -> None:
         """
@@ -51,7 +51,7 @@ class JournaldUtils(MultihostUtility[MultihostHost]):
         :return: List of artifacts to collect.
         :rtype: set[str]
         """
-        self.host.conn.run(f"journalctl --since '{self._test_start}' > /var/log/journald.log")
+        self.conn.run(f"journalctl --since '{self._test_start}' > /var/log/journald.log")
         return {"/var/log/journald.log"}
 
     def clear(self) -> None:
@@ -122,7 +122,7 @@ class JournaldUtils(MultihostUtility[MultihostHost]):
             "no-pager": (cli.option.SWITCH, True),
         }
 
-        return self.host.conn.exec(["journalctl"] + cli.args(builder) + args, raise_on_error=False)
+        return self.conn.exec(["journalctl"] + cli.args(builder) + args, raise_on_error=False)
 
     def is_match(self, pattern: str, unit: str | None = None) -> bool:
         """

--- a/pytest_mh/utils/services.py
+++ b/pytest_mh/utils/services.py
@@ -39,13 +39,13 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         self.reload_daemon()
         for service, state in self.initial_states.items():
             self.logger.info(f'systemd: restoring "{service}" to {"started" if state else "stopped"}')
-            self.host.conn.run(
+            self.conn.run(
                 self._debug_failure(service, f'systemctl stop "{service}"'),
                 raise_on_error=False,
                 log_level=ProcessLogLevel.Error,
             )
             if state:
-                self.host.conn.run(
+                self.conn.run(
                     self._debug_failure(service, f'systemctl start "{service}"'),
                     raise_on_error=False,
                     log_level=ProcessLogLevel.Error,
@@ -67,7 +67,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         """
         self.__set_initial_state(service)
         self.logger.info(f'systemd: starting "{service}" asynchronously')
-        return self.host.conn.async_run(
+        return self.conn.async_run(
             self._debug_failure(service, f'systemctl reset-failed "{service}"; systemctl start "{service}"'),
             log_level=ProcessLogLevel.Error,
         )
@@ -88,7 +88,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         """
         self.__set_initial_state(service)
         self.logger.info(f'systemd: starting "{service}"')
-        return self.host.conn.run(
+        return self.conn.run(
             self._debug_failure(service, f'systemctl reset-failed "{service}"; systemctl start "{service}"'),
             raise_on_error=raise_on_error,
             log_level=ProcessLogLevel.Error,
@@ -108,7 +108,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         """
         self.__set_initial_state(service)
         self.logger.info(f'systemd: stopping "{service}" asynchronously')
-        return self.host.conn.async_run(
+        return self.conn.async_run(
             self._debug_failure(service, f'systemctl stop "{service}"'), log_level=ProcessLogLevel.Error
         )
 
@@ -128,7 +128,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         """
         self.__set_initial_state(service)
         self.logger.info(f'systemd: stopping "{service}"')
-        return self.host.conn.run(
+        return self.conn.run(
             self._debug_failure(service, f'systemctl stop "{service}"'),
             raise_on_error=raise_on_error,
             log_level=ProcessLogLevel.Error,
@@ -148,7 +148,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         """
         self.__set_initial_state(service)
         self.logger.info(f'systemd: restarting "{service}" asynchronously')
-        return self.host.conn.async_run(
+        return self.conn.async_run(
             self._debug_failure(service, f'systemctl reset-failed "{service}"; systemctl restart "{service}"'),
             log_level=ProcessLogLevel.Error,
         )
@@ -169,7 +169,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         """
         self.__set_initial_state(service)
         self.logger.info(f'systemd: restarting "{service}"')
-        return self.host.conn.run(
+        return self.conn.run(
             self._debug_failure(service, f'systemctl reset-failed "{service}"; systemctl restart "{service}"'),
             raise_on_error=raise_on_error,
             log_level=ProcessLogLevel.Error,
@@ -188,7 +188,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         :rtype: Process
         """
         self.logger.info(f'systemd: reloading "{service}" asynchronously')
-        return self.host.conn.async_run(
+        return self.conn.async_run(
             self._debug_failure(service, f'systemctl reload "{service}"'), log_level=ProcessLogLevel.Error
         )
 
@@ -207,7 +207,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         :rtype: ProcessResult
         """
         self.logger.info(f'systemd: reloading "{service}"')
-        return self.host.conn.run(
+        return self.conn.run(
             self._debug_failure(service, f'systemctl reload "{service}"'),
             raise_on_error=raise_on_error,
             log_level=ProcessLogLevel.Error,
@@ -222,7 +222,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         :return: Running SSH process.
         :rtype: Process
         """
-        return self.host.conn.async_run(f'systemctl status "{service}"')
+        return self.conn.async_run(f'systemctl status "{service}"')
 
     def status(self, service: str, raise_on_error: bool = True) -> ProcessResult:
         """
@@ -235,7 +235,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         :return: SSH process result.
         :rtype: ProcessResult
         """
-        return self.host.conn.run(f'systemctl status "{service}"', raise_on_error=raise_on_error)
+        return self.conn.run(f'systemctl status "{service}"', raise_on_error=raise_on_error)
 
     def async_get_property(self, service: str, prop: str) -> Process:
         """
@@ -248,7 +248,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         :return: Running SSH process.
         :rtype: Process
         """
-        return self.host.conn.async_run(f'systemctl show "{service}" --value --property "{prop}"')
+        return self.conn.async_run(f'systemctl show "{service}" --value --property "{prop}"')
 
     def get_property(self, service: str, prop: str, raise_on_error: bool = True) -> str:
         """
@@ -263,7 +263,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         :return: property value as string.
         :rtype: str
         """
-        result = self.host.conn.run(
+        result = self.conn.run(
             f'systemctl show "{service}" --value --property "{prop}"', raise_on_error=raise_on_error
         )
         return result.stdout.strip()
@@ -276,7 +276,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         :rtype: Process
         """
         self.logger.info("systemd: reloading systemd daemon")
-        return self.host.conn.async_run("systemctl daemon-reload", log_level=ProcessLogLevel.Error)
+        return self.conn.async_run("systemctl daemon-reload", log_level=ProcessLogLevel.Error)
 
     def reload_daemon(self, raise_on_error: bool = True) -> ProcessResult:
         """
@@ -287,7 +287,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         :return: SSH process result.
         :rtype: ProcessResult
         """
-        return self.host.conn.run("systemctl daemon-reload", raise_on_error=raise_on_error)
+        return self.conn.run("systemctl daemon-reload", raise_on_error=raise_on_error)
 
     def _debug_failure(self, service: str, command: str) -> str:
         return f"{command} || ({self._query_logs_command(service)})"
@@ -309,9 +309,7 @@ class SystemdServices(MultihostReentrantUtility[MultihostHost]):
         if service in self.initial_states:
             return
 
-        result = self.host.conn.run(
-            f'systemctl status "{service}"', log_level=ProcessLogLevel.Silent, raise_on_error=False
-        )
+        result = self.conn.run(f'systemctl status "{service}"', log_level=ProcessLogLevel.Silent, raise_on_error=False)
 
         if result.rc == 0 or (result.rc == 3 and "Active: activating" in result.stdout):
             self.initial_states[service] = True

--- a/pytest_mh/utils/tc.py
+++ b/pytest_mh/utils/tc.py
@@ -33,7 +33,7 @@ class LinuxTrafficControl(MultihostUtility[MultihostHost]):
         super().setup()
 
         # Let's find out the available interfaces
-        result = self.host.conn.run("ip -o address", log_level=ProcessLogLevel.Error)
+        result = self.conn.run("ip -o address", log_level=ProcessLogLevel.Error)
         split_result = result.stdout.splitlines()
 
         for line in split_result:
@@ -48,7 +48,7 @@ class LinuxTrafficControl(MultihostUtility[MultihostHost]):
             )
             self.__restore_root.add(f"tc qdisc del dev {interface} root")
 
-        self.host.conn.run(commands, log_level=ProcessLogLevel.Error)
+        self.conn.run(commands, log_level=ProcessLogLevel.Error)
 
     def teardown(self) -> None:
         """
@@ -59,7 +59,7 @@ class LinuxTrafficControl(MultihostUtility[MultihostHost]):
         tear: str = ""
         for iter in self.__restore_root:
             tear += iter + "\n"
-        self.host.conn.run(tear, log_level=ProcessLogLevel.Error)
+        self.conn.run(tear, log_level=ProcessLogLevel.Error)
         super().teardown()
 
     def _get_hostname(self, host: str | MultihostHost | MultihostRole) -> str:
@@ -93,7 +93,7 @@ class LinuxTrafficControl(MultihostUtility[MultihostHost]):
 
         self.logger.info(f"Adding network delay {time_unit} to {hostname}")
 
-        ips = self.host.conn.run(f"dig +short {hostname}", log_level=ProcessLogLevel.Error)
+        ips = self.conn.run(f"dig +short {hostname}", log_level=ProcessLogLevel.Error)
         ip_list = ips.stdout.splitlines()
 
         commands = "set -e\n"
@@ -109,7 +109,7 @@ class LinuxTrafficControl(MultihostUtility[MultihostHost]):
                 )
                 self.__restore_filters[ip] = self.__band
 
-        self.host.conn.run(commands, log_level=ProcessLogLevel.Error)
+        self.conn.run(commands, log_level=ProcessLogLevel.Error)
         self.__band += 1
 
     def remove_delay(self, host: str | MultihostHost | MultihostRole):
@@ -123,7 +123,7 @@ class LinuxTrafficControl(MultihostUtility[MultihostHost]):
 
         self.logger.info(f"Removing network delay to {hostname}")
 
-        ips = self.host.conn.run(f"dig +short {hostname}", log_level=ProcessLogLevel.Error)
+        ips = self.conn.run(f"dig +short {hostname}", log_level=ProcessLogLevel.Error)
         ip_list = ips.stdout.splitlines()
 
         bands: set[int] = set()
@@ -138,4 +138,4 @@ class LinuxTrafficControl(MultihostUtility[MultihostHost]):
 
             commands += f"tc qdisc del dev {interface} parent 1:{band} handle {band * 10}: netem\n"
 
-        self.host.conn.run(commands, log_level=ProcessLogLevel.Error)
+        self.conn.run(commands, log_level=ProcessLogLevel.Error)


### PR DESCRIPTION
The main purpose of pytest-mh is to allow executing commands on the
hosts. Therefore it is natural to provide conneciton via a shortcut
instead of writing `host.conn` everywhere.