### PR TITLE
 markers: new preferred_topology marker

### DIFF
--- a/docs/articles/tips-and-tricks.rst
+++ b/docs/articles/tips-and-tricks.rst
@@ -11,3 +11,4 @@ inspiration for your project.
     tips-and-tricks/building-command-line
     tips-and-tricks/features-detection
     tips-and-tricks/pytest-fixtures
+    tips-and-tricks/preferred-topology

--- a/docs/articles/tips-and-tricks/preferred-topology.rst
+++ b/docs/articles/tips-and-tricks/preferred-topology.rst
@@ -1,0 +1,34 @@
+Preferred Topology
+==================
+
+The preferred topology marker ``pytest.mark.preferred_topology`` can be
+used if you want the flexibility to run against all topologies, but do not
+need to do it all the time. An example could be Nightly builds or a CI where
+a single topology is adequate coverage. This will reduce the resources
+required to run the tests and their execution times. This is possible by using
+the ``pytest.mark.preferred_topology`` marker.
+
+This marks the test with a default topology, deselecting any additional
+topologies. ``--mh-ignore-preferred-topology`` can be used to ignore the
+marker.
+
+If more than one preferred topology has been defined, only the last topology
+will be used. If the preferred topology contains no value, the marker is
+ignored.The ``pytest.mark.preferred_topology`` marker accepts three types of
+values, :class:`~pytest_mh.TopologyMark` value of
+:class:`~pytest_mh.KnownTopologyBase` or ``str``.
+
+.. code-block:: python
+    :caption:  Example: set preferred topology to IPA
+
+
+    @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+    @pytest.mark.preferred_topology(KnownTopology.IPA)
+    def test_preferred_mark_known_topology_ipa():
+        pass
+
+
+    @pytest.mark.topology(KnownTopologyGroup.AnyProvider)
+    @pytest.mark.preferred_topology("ipa")
+    def test_preferred_mark_string_ipa():
+        pass

--- a/pytest_mh/_private/data.py
+++ b/pytest_mh/_private/data.py
@@ -54,7 +54,7 @@ class MultihostItemData(object):
 
     @staticmethod
     def GetData(item: pytest.Item) -> MultihostItemData | None:
-        return item.stash[DataStashKey]
+        return item.stash.get(DataStashKey, None)
 
 
 DataStashKey = pytest.StashKey[MultihostItemData | None]()


### PR DESCRIPTION
  Reducing test running time and system resources, we can now mark
 a test with @pytest.mark.preferred_topology(KnownTopology.topology),
 making the topology the single and default run unless the marker is
 overridden. This is intended to be used for tests that do not need
 to cover all topologies all the time.
