### PR TITLE
Workaround timeout issue with SSH_AUTH_AGAIN

### DIFF
--- a/pytest_mh/conn/ssh.py
+++ b/pytest_mh/conn/ssh.py
@@ -454,7 +454,7 @@ class SSHClient(Connection[SSHProcess, SSHProcessResult]):
         # since Python will not deliver signal if the code is blocked in C
         # library. The signal is deliver only after we get back to the Python
         # code.
-        self.__conn: LibsshSession = LibsshSession(timeout=1)
+        self.__conn: LibsshSession = LibsshSession()
 
     def _read_private_key(
         self,
@@ -518,6 +518,7 @@ class SSHClient(Connection[SSHProcess, SSHProcessResult]):
                 port=self.port,
                 host_key_checking=False,
             )
+            self.__conn.set_ssh_options("timeout", 1)
         except LibsshSessionException as e:
             raise SSHAuthenticationError(self.host, self.port, self.user, e.message)
 


### PR DESCRIPTION
When the timeout is set to 1 in LibsshSession(timeout=1), pylibssh no longer returns an exception for a wrong password SSH connect()

    with pytest.raises(SSHAuthenticationError):
        client.ssh("user1", "Wrong").connect()

Increase the minimum timeout a couple seconds here.

Regarding 'LibsshSession(timeout=1)', a very low value must be set here, to allow the timeout set in

        client.host.conn.run(..., timeout=X)

to work as expected. This is due to code becoming blocked in libssh which is C not Python, but the Python signal is delayed until we get back to the Python code