### PR TITLE
requirements: Workaround pylibssh Failed to open session

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,6 @@ add_imports = "from __future__ import annotations"
 
 [tool.black]
 line-length = 119
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible-pylibssh>=1.2.0
+ansible-pylibssh@git+https://github.com/justin-stephenson/pylibssh@retry_ssh_again
 colorama
 pytest
 PyYAML


### PR DESCRIPTION
Install from Justin's branch with pylibssh workaround for `SSH_AGAIN` return code issue.

pyproject.toml change was needed or installing generates error:

```
(.venv) justin@fedora:~/github/sssd/src/tests/system$ pip3 install -e ~/github/pytest-mh/                                                                                                                                                  10:10:06 [181/500]
Obtaining file:///home/justin/github/pytest-mh                                                                                                                                                                           
  Installing build dependencies ... done                                                                                                                                                                                 
  Checking if build backend supports build_editable ... done                                                                                                                                                             
  Getting requirements to build editable ... done                                                                                                                                                                        
  Installing backend dependencies ... done                                                                                                                                                                               
  Preparing editable metadata (pyproject.toml) ... error                                                                                                                                                                 
  error: subprocess-exited-with-error                                                                                                                                                                                    
                                                                                                                                                                                                                         
  × Preparing editable metadata (pyproject.toml) did not run successfully.                                                                                                                                               
  │ exit code: 1                                                                                                                                                                                                         
  ╰─> [35 lines of output]                                                                                                                                                                                               
      Traceback (most recent call last):                                                                                                                                                                                 
        File "/home/justin/github/sssd/src/tests/system/.venv/lib64/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 167, in prepare_metadata_for_build_editable                    
          hook = backend.prepare_metadata_for_build_editable                                                                                                                                                             
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                             
      AttributeError: module 'hatchling.build' has no attribute 'prepare_metadata_for_build_editable'                                                                                                                    
                                                                                                                                                                                                                         
      During handling of the above exception, another exception occurred:                                                                                                                                                
                                                                                                                                                                                                                         
      Traceback (most recent call last):                                                                                                                                                                                 
        File "/home/justin/github/sssd/src/tests/system/.venv/lib64/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>                                               
          main()                                                                                                                                                                                                         
          ~~~~^^                                                                                                                                                                                                         
        File "/home/justin/github/sssd/src/tests/system/.venv/lib64/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])                                                               
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^                                                                
        File "/home/justin/github/sssd/src/tests/system/.venv/lib64/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 176, in prepare_metadata_for_build_editable
          whl_basename = build_hook(metadata_directory, config_settings)                                                       
        File "/tmp/pip-build-env-2nlf93fw/overlay/lib/python3.13/site-packages/hatchling/build.py", line 83, in build_editable 
          return os.path.basename(next(builder.build(directory=wheel_directory, versions=['editable'])))                      
                                  ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                       
        File "/tmp/pip-build-env-2nlf93fw/overlay/lib/python3.13/site-packages/hatchling/builders/plugin/interface.py", line 90, in build
          self.metadata.validate_fields()                      
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^                      
        File "/tmp/pip-build-env-2nlf93fw/overlay/lib/python3.13/site-packages/hatchling/metadata/core.py", line 266, in validate_fields
          self.core.validate_fields()                          
          ~~~~~~~~~~~~~~~~~~~~~~~~~^^                          
        File "/tmp/pip-build-env-2nlf93fw/overlay/lib/python3.13/site-packages/hatchling/metadata/core.py", line 1366, in validate_fields
          getattr(self, attribute)                             
          ~~~~~~~^^^^^^^^^^^^^^^^^                             
        File "/tmp/pip-build-env-2nlf93fw/overlay/lib/python3.13/site-packages/hatchling/metadata/core.py", line 1220, in dependencies
          self._dependencies = list(self.dependencies_complex)                                                                
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                 
        File "/tmp/pip-build-env-2nlf93fw/overlay/lib/python3.13/site-packages/hatchling/metadata/core.py", line 1205, in dependencies_complex
          raise ValueError(message)                            
      ValueError: Dependency #1 of field `project.dependencies` cannot be a direct reference unless field `tool.hatch.metadata.allow-direct-references` is set to `true`
      [end of output]                                          
                                                               
  note: This error originates from a subprocess, and is likely not a problem with pip.    
```