### PR TITLE
Add file check to auditd for log files

### DIFF
--- a/pytest_mh/utils/auditd.py
+++ b/pytest_mh/utils/auditd.py
@@ -89,10 +89,13 @@ class Auditd(MultihostUtility[MultihostHost]):
                 f"""
                 set -e
 
-                for f in "{self._backup}"/audit/audit.log*; do
-                    name=`basename "$f"`
-                    cat "$f" > "/var/log/audit/$name"
-                done
+                path="{self._backup}"/audit
+                if [ -d "$path" ] && [ -n "$(ls -A $path)" ]; then
+                    for f in "{self._backup}"/audit/audit.log*; do
+                        name=`basename "$f"`
+                        cat "$f" > "/var/log/audit/$name"
+                    done
+                fi
 
                 rm -fr "{self._backup}"
                 """,


### PR DESCRIPTION
In some cases, log files are cleaned up before the auditd teardown can
perform it's cleanup.   Adding a check to see if the files exist before
running restore and cleanup.  If no files found, exit and skip.