### PR TITLE
ssh: set ansible-pylibssh logging to INFO

### DIFF
--- a/example/framework/hosts/ldap.py
+++ b/example/framework/hosts/ldap.py
@@ -86,7 +86,7 @@ class LDAPHost(BaseHost):
             if len(result) != 1:
                 raise ValueError(f"Unexpected number of results for rootDSE query: {len(result)}")
 
-            (_, values) = result[0]
+            _, values = result[0]
             if attr not in values:
                 raise ValueError(f"Unable to find {attr}")
 

--- a/example/framework/topology_controllers.py
+++ b/example/framework/topology_controllers.py
@@ -72,11 +72,9 @@ class BaseTopologyController(BackupTopologyController[SUDOMultihostConfig]):
         )
 
         # Remove SSSD data to start fresh
-        client.conn.run(
-            """
+        client.conn.run("""
             rm -fr /var/lib/sss/db/* /var/lib/sss/mc/* /var/log/sssd/*
-            """
-        )
+            """)
 
 
 class SudoersTopologyController(BaseTopologyController):

--- a/pytest_mh/_private/misc.py
+++ b/pytest_mh/_private/misc.py
@@ -80,7 +80,7 @@ def validate_configuration(
 
     def is_property_in_dict(property: str, d: dict[str, Any]) -> bool:
         if "." in property:
-            (key, subpath) = property.split(".", maxsplit=1)
+            key, subpath = property.split(".", maxsplit=1)
             if not d.get(key, None):
                 return False
 

--- a/pytest_mh/cli.py
+++ b/pytest_mh/cli.py
@@ -160,7 +160,7 @@ class CLIBuilder(object):
             if item is None:
                 continue
 
-            (type, value) = item
+            type, value = item
             if value is None:
                 continue
 

--- a/pytest_mh/conn/__init__.py
+++ b/pytest_mh/conn/__init__.py
@@ -109,18 +109,14 @@ class ProcessErrorBase(Exception):
 
             return "\n" + textwrap.indent(value, " " * 20)
 
-        super().__init__(
-            textwrap.dedent(
-                f"""
+        super().__init__(textwrap.dedent(f"""
                 Command #{id} {message}:
                   Command:{dumps(command)}
                   CWD:{dumps(cwd)}
                   Env:{dumps(pretty_env.strip())}
                   Output:{dumps(str_stdout)}
                   Error output:{dumps(str_stderr)}
-                """
-            )
-        )
+                """))
 
         self.message: str = message
         """Error message."""

--- a/pytest_mh/conn/ssh.py
+++ b/pytest_mh/conn/ssh.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import signal
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator, Self
@@ -520,6 +521,7 @@ class SSHClient(Connection[SSHProcess, SSHProcessResult]):
                 open_session_retries=10,
             )
             self.__conn.set_ssh_options("timeout", 1)
+            self.__conn.set_log_level(logging.INFO)
         except LibsshSessionException as e:
             raise SSHAuthenticationError(self.host, self.port, self.user, e.message)
 

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -37,13 +37,11 @@ def test_conn__shell_bash__cwd():
     assert shell.shell_command == "/usr/bin/env bash -c"
 
     cmd = shell.build_command_line("echo hello world", cwd="/home/test", env={})
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
         cd /home/test
 
         echo hello world
-        """
-    ).strip()
+        """).strip()
     assert cmd == f"{shell.shell_command} '{expected}'"
 
 
@@ -54,14 +52,12 @@ def test_conn__shell_bash__env():
     assert shell.shell_command == "/usr/bin/env bash -c"
 
     cmd = shell.build_command_line("echo hello world", cwd=None, env={"HELLO": "WORLD", "JOHN": "DOE"})
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
         export HELLO=WORLD
         export JOHN=DOE
 
         echo hello world
-        """
-    ).strip()
+        """).strip()
     assert cmd == f"{shell.shell_command} '{expected}'"
 
 
@@ -72,15 +68,13 @@ def test_conn__shell_bash__cwd_env():
     assert shell.shell_command == "/usr/bin/env bash -c"
 
     cmd = shell.build_command_line("echo hello world", cwd="/home/test", env={"HELLO": "WORLD", "JOHN": "DOE"})
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
         export HELLO=WORLD
         export JOHN=DOE
         cd /home/test
 
         echo hello world
-        """
-    ).strip()
+        """).strip()
     assert cmd == f"{shell.shell_command} '{expected}'"
 
 
@@ -114,13 +108,11 @@ def test_conn__shell_powershell__cwd():
     assert shell.shell_command == "powershell -NonInteractive -Command"
 
     cmd = shell.build_command_line("Write-Output hello world", cwd="/home/test", env={})
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
         cd /home/test
 
         Write-Output hello world
-        """
-    ).strip()
+        """).strip()
     assert cmd == f"{shell.shell_command} '{expected}'"
 
 
@@ -131,14 +123,12 @@ def test_conn__shell_powershell__env():
     assert shell.shell_command == "powershell -NonInteractive -Command"
 
     cmd = shell.build_command_line("Write-Output hello world", cwd=None, env={"HELLO": "WORLD", "JOHN": "DOE"})
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
         $Env:HELLO = WORLD
         $Env:JOHN = DOE
 
         Write-Output hello world
-        """
-    ).strip()
+        """).strip()
     assert cmd == f"{shell.shell_command} '{expected}'"
 
 
@@ -149,13 +139,11 @@ def test_conn__shell_powershell__cwd_env():
     assert shell.shell_command == "powershell -NonInteractive -Command"
 
     cmd = shell.build_command_line("echo hello world", cwd="/home/test", env={"HELLO": "WORLD", "JOHN": "DOE"})
-    expected = textwrap.dedent(
-        """
+    expected = textwrap.dedent("""
         $Env:HELLO = WORLD
         $Env:JOHN = DOE
         cd /home/test
 
         echo hello world
-        """
-    ).strip()
+        """).strip()
     assert cmd == f"{shell.shell_command} '{expected}'"


### PR DESCRIPTION
ansible-pylibssh version 1.4.0 defaults to debug logging to the main pytest logging.  This is causing excessive log messages in the pytest run log.   This is to limit the logging.