### PR TITLE
fix: Use base64 for transport in conn to avoid quote escape hell.

### DIFF
--- a/pytest_mh/conn/__init__.py
+++ b/pytest_mh/conn/__init__.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import base64
 import itertools
 import os
+import re
 import shlex
 import signal
 import textwrap
+import xml.etree.ElementTree as ET
 from abc import ABC, abstractmethod
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any, Generator, Generic, NoReturn, Self, TypeVar
@@ -1149,6 +1152,10 @@ class Shell(ABC):
         self.shell_command: str = shell_command
         """Shell command that will execute user scripts."""
 
+    def sanitize_stderr(self, stderr: list[str]) -> list[str]:
+        """Return stderr lines; subclasses may strip shell-specific noise."""
+        return stderr
+
     @abstractmethod
     def build_command_line(self, script: str, *, cwd: str | None, env: dict[str, Any]) -> str:
         """
@@ -1217,19 +1224,58 @@ class Bash(Shell):
 class Powershell(Shell):
     """
     Powershell shell abstraction.
+
+    Scripts are passed via ``-EncodedCommand`` (UTF-16LE base64) so quoting stays
+    intact when the SSH login shell is bash (e.g. Cygwin) or cmd.
     """
 
+    _CLIXML_NS = "http://schemas.microsoft.com/powershell/2004/04"
+    _CLIXML_HEX_RE = re.compile(r"_x([0-9A-Fa-f]{4})_")
+    # EncodedCommand + redirected stderr emits progress/errors as CLIXML.
+    _SCRIPT_PREAMBLE = "$ProgressPreference = 'SilentlyContinue'\n"
+
     def __init__(self) -> None:
-        super().__init__("powershell", "powershell -NonInteractive -Command")
+        # -OutputFormat Text: prefer text streams; CLIXML may still appear (see sanitize_stderr)
+        super().__init__(
+            "powershell",
+            "powershell -NonInteractive -OutputFormat Text -EncodedCommand",
+        )
 
     def build_command_line(self, script: str, *, cwd: str | None, env: dict[str, Any]) -> str:
         full_script = self._add_cwd_and_env(script, cwd=cwd, env=env)
-        escaped_script = self._escape_quotes(full_script)
+        encoded = base64.b64encode(full_script.encode("utf-16-le")).decode("ascii")
 
-        return f"{self.shell_command} '{escaped_script}'"
+        return f"{self.shell_command} {encoded}"
+
+    def sanitize_stderr(self, stderr: list[str]) -> list[str]:
+        text = "\n".join(stderr)
+        if "#< CLIXML" not in text and "#<CLIXML" not in text:
+            return stderr
+
+        lines: list[str] = []
+        for chunk in re.split(r"#<\s*CLIXML", text):
+            chunk = chunk.strip()
+            if not chunk:
+                continue
+            try:
+                root = ET.fromstring(chunk)
+            except ET.ParseError:
+                continue
+            for node in root.iter(f"{{{self._CLIXML_NS}}}S"):
+                stream = node.get("S")
+                if stream not in (None, "Error", "Warning"):
+                    continue
+                decoded = self._decode_clixml_text(node.text or "").rstrip("\r\n")
+                if decoded:
+                    lines.extend(decoded.splitlines())
+
+        return lines
+
+    def _decode_clixml_text(self, value: str) -> str:
+        return self._CLIXML_HEX_RE.sub(lambda m: chr(int(m.group(1), 16)), value)
 
     def _add_cwd_and_env(self, script: str, *, cwd: str | None, env: dict[str, Any]) -> str:
-        out = ""
+        out = self._SCRIPT_PREAMBLE
 
         # Set environment variables
         for key, value in env.items():
@@ -1239,15 +1285,9 @@ class Powershell(Shell):
         if cwd is not None:
             out += f"cd {shlex.quote(cwd)}\n"
 
-        if out:
+        if env or cwd is not None:
             out += "\n"
 
         out += script
 
         return out
-
-    def _escape_quotes(self, command: str) -> str:
-        """
-        We need to escape quotes inside the script to make it work correctly.
-        """
-        return command.replace("'", "''").replace('"', '\\"')

--- a/pytest_mh/conn/ssh.py
+++ b/pytest_mh/conn/ssh.py
@@ -341,12 +341,13 @@ class SSHProcess(Process[SSHProcessResult, SSHInputBuffer, SSHProcessTimeoutErro
             self.__stdout.finish()
             self.__stderr.finish()
 
+            stderr = self.shell.sanitize_stderr(self.__stderr.lines)
             error = SSHProcessError(
-                code, self.id, self.command, self.cwd, self.env, self.input, self.__stdout.lines, self.__stderr.lines
+                code, self.id, self.command, self.cwd, self.env, self.input, self.__stdout.lines, stderr
             )
 
             result = SSHProcessResult(
-                code, self.__stdout.lines, self.__stderr.lines, error, unified_newlines=self.__unified_newlines
+                code, self.__stdout.lines, stderr, error, unified_newlines=self.__unified_newlines
             )
         except TimeoutError as e:
             self.__stdout.read_once_into_buffer()
@@ -354,9 +355,8 @@ class SSHProcess(Process[SSHProcessResult, SSHInputBuffer, SSHProcessTimeoutErro
             stdout = (
                 [line.rstrip("\r") for line in self.__stdout.lines] if self.__unified_newlines else self.__stdout.lines
             )
-            stderr = (
-                [line.rstrip("\r") for line in self.__stderr.lines] if self.__unified_newlines else self.__stderr.lines
-            )
+            stderr = self.shell.sanitize_stderr(self.__stderr.lines)
+            stderr = [line.rstrip("\r") for line in stderr] if self.__unified_newlines else stderr
             raise SSHProcessTimeoutError(
                 e.args[0],
                 self.id,

--- a/tests/test_conn.py
+++ b/tests/test_conn.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+import base64
 import textwrap
 
 import pytest
 
 from pytest_mh.conn import Bash, Powershell
+
+
+def _ps_encoded(script: str) -> str:
+    return base64.b64encode(script.encode("utf-16-le")).decode("ascii")
+
+
+def _ps_script(body: str) -> str:
+    return f"$ProgressPreference = 'SilentlyContinue'\n{body}"
 
 
 @pytest.mark.parametrize(
@@ -79,11 +88,11 @@ def test_conn__shell_bash__cwd_env():
 
 
 @pytest.mark.parametrize(
-    "input, expected",
+    "input",
     [
-        ("Write-Output hello world", "Write-Output hello world"),
-        ('Write-Output "hello world"', 'Write-Output \\"hello world\\"'),
-        ("Write-Output 'hello world'", "Write-Output ''hello world''"),
+        "Write-Output hello world",
+        'Write-Output "hello world"',
+        "Write-Output 'hello world'",
     ],
     ids=[
         "no-quotes",
@@ -91,59 +100,103 @@ def test_conn__shell_bash__cwd_env():
         "single-quotes",
     ],
 )
-def test_conn__shell_powershell__script(input: str, expected: str):
+def test_conn__shell_powershell__script(input: str):
     shell = Powershell()
 
     assert shell.name == "powershell"
-    assert shell.shell_command == "powershell -NonInteractive -Command"
+    assert shell.shell_command == "powershell -NonInteractive -OutputFormat Text -EncodedCommand"
 
     cmd = shell.build_command_line(input, cwd=None, env={})
-    assert cmd == f"{shell.shell_command} '{expected}'"
+    assert cmd == f"{shell.shell_command} {_ps_encoded(_ps_script(input))}"
 
 
 def test_conn__shell_powershell__cwd():
     shell = Powershell()
 
     assert shell.name == "powershell"
-    assert shell.shell_command == "powershell -NonInteractive -Command"
+    assert shell.shell_command == "powershell -NonInteractive -OutputFormat Text -EncodedCommand"
 
     cmd = shell.build_command_line("Write-Output hello world", cwd="/home/test", env={})
-    expected = textwrap.dedent("""
+    expected = _ps_script(textwrap.dedent("""
         cd /home/test
 
         Write-Output hello world
-        """).strip()
-    assert cmd == f"{shell.shell_command} '{expected}'"
+        """).strip())
+    assert cmd == f"{shell.shell_command} {_ps_encoded(expected)}"
 
 
 def test_conn__shell_powershell__env():
     shell = Powershell()
 
     assert shell.name == "powershell"
-    assert shell.shell_command == "powershell -NonInteractive -Command"
+    assert shell.shell_command == "powershell -NonInteractive -OutputFormat Text -EncodedCommand"
 
     cmd = shell.build_command_line("Write-Output hello world", cwd=None, env={"HELLO": "WORLD", "JOHN": "DOE"})
-    expected = textwrap.dedent("""
+    expected = _ps_script(textwrap.dedent("""
         $Env:HELLO = WORLD
         $Env:JOHN = DOE
 
         Write-Output hello world
-        """).strip()
-    assert cmd == f"{shell.shell_command} '{expected}'"
+        """).strip())
+    assert cmd == f"{shell.shell_command} {_ps_encoded(expected)}"
 
 
 def test_conn__shell_powershell__cwd_env():
     shell = Powershell()
 
     assert shell.name == "powershell"
-    assert shell.shell_command == "powershell -NonInteractive -Command"
+    assert shell.shell_command == "powershell -NonInteractive -OutputFormat Text -EncodedCommand"
 
     cmd = shell.build_command_line("echo hello world", cwd="/home/test", env={"HELLO": "WORLD", "JOHN": "DOE"})
-    expected = textwrap.dedent("""
+    expected = _ps_script(textwrap.dedent("""
         $Env:HELLO = WORLD
         $Env:JOHN = DOE
         cd /home/test
 
         echo hello world
-        """).strip()
-    assert cmd == f"{shell.shell_command} '{expected}'"
+        """).strip())
+    assert cmd == f"{shell.shell_command} {_ps_encoded(expected)}"
+
+
+def test_conn__shell_powershell__sanitize_stderr_progress_only():
+    shell = Powershell()
+    ns = "http://schemas.microsoft.com/powershell/2004/04"
+    clixml = "\n".join(
+        [
+            "#< CLIXML",
+            f'<Objs Version="1.1.0.1" xmlns="{ns}">'
+            '<Obj S="progress" RefId="0">'
+            '<TN RefId="0"><T>System.Management.Automation.PSCustomObject</T>'
+            "<T>System.Object</T></TN>"
+            '<MS><I64 N="SourceId">1</I64>'
+            '<PR N="Record"><AV>Loading Active Directory module</AV>'
+            "<AI>0</AI><Nil /><PI>-1</PI><PC>100</PC>"
+            "<T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>",
+        ]
+    )
+    assert shell.sanitize_stderr(clixml.splitlines()) == []
+
+
+def test_conn__shell_powershell__sanitize_stderr_keeps_errors():
+    shell = Powershell()
+    ns = "http://schemas.microsoft.com/powershell/2004/04"
+    clixml = "\n".join(
+        [
+            "#< CLIXML",
+            f'<Objs Version="1.1.0.1" xmlns="{ns}">'
+            '<Obj S="progress" RefId="0">'
+            '<TN RefId="0"><T>System.Management.Automation.PSCustomObject</T>'
+            "<T>System.Object</T></TN>"
+            '<MS><I64 N="SourceId">1</I64>'
+            '<PR N="Record"><AV>Loading Active Directory module</AV>'
+            "<AI>0</AI><Nil /><PI>-1</PI><PC>100</PC>"
+            "<T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj>"
+            '<S S="Error">Get-ADComputer : Cannot find an object '
+            "with identity: 'client'._x000D__x000A_</S>"
+            '<S S="Error">At line:2 char:1_x000D__x000A_</S></Objs>',
+        ]
+    )
+    assert shell.sanitize_stderr(clixml.splitlines()) == [
+        "Get-ADComputer : Cannot find an object with identity: 'client'.",
+        "At line:2 char:1",
+    ]


### PR DESCRIPTION
Quotes are being lost between python/cygwin/powershell resulting in failures like this one:

INTERNALERROR>     # Backup computers
INTERNALERROR>     $backup_computers = Join-Path $tmpdir computers.txt
INTERNALERROR>     $result = Get-ADObject -SearchBase "cn=computers,$basedn" -LDAPFilter "(objectClass=computer)"
INTERNALERROR>     foreach ($r in $result) { $r.DistinguishedName | Add-Content -Path $backup_computers }
INTERNALERROR> 
INTERNALERROR>     Write-Output $tmpdir.FullName
INTERNALERROR>   CWD:
INTERNALERROR>   Env:
INTERNALERROR>   Output:
INTERNALERROR>   Error output:
INTERNALERROR>     At line:1 char:19
INTERNALERROR>     + $basedn = DC=child,DC=ad-ed1r,DC=test
INTERNALERROR>     +                   ~
INTERNALERROR>     Missing argument in parameter list.
INTERNALERROR>     At line:17 char:33
INTERNALERROR>     + | Where-Object { $_.ZoneType -eq \"Primary\" -and $_.IsAutoCreated -e ...
INTERNALERROR>     +                                 ~
INTERNALERROR>     You must provide a value expression following the '-eq' operator.
INTERNALERROR>     At line:17 char:34
INTERNALERROR>     + | Where-Object { $_.ZoneType -eq \"Primary\" -and $_.IsAutoCreated -e ...
INTERNALERROR>     +                                  ~~~~~~~~~~~
INTERNALERROR>     Unexpected token '\"Primary\"' in expression or statement.
INTERNALERROR>         + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
INTERNALERROR>         + FullyQualifiedErrorId : MissingArgument

Use base64 encoded commands instead.